### PR TITLE
chore: partial revert of 180f5a96 to restore methods for binary compatibility

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/CollectionReference.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/CollectionReference.java
@@ -28,6 +28,7 @@ import com.google.firestore.v1.Document;
 import com.google.firestore.v1.DocumentMask;
 import com.google.firestore.v1.ListDocumentsRequest;
 import java.util.Iterator;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -170,13 +171,13 @@ public class CollectionReference extends Query {
    * Adds a new document to this collection with the specified data, assigning it a document ID
    * automatically.
    *
-   * @param fields The Map or POJO containing the data for the new document.
+   * @param fields A Map containing the data for the new document.
    * @return An ApiFuture that will be resolved with the DocumentReference of the newly created
    *     document.
    * @see #document()
    */
   @Nonnull
-  public ApiFuture<DocumentReference> add(@Nonnull final Object fields) {
+  public ApiFuture<DocumentReference> add(@Nonnull final Map<String, Object> fields) {
     final DocumentReference documentReference = document();
     ApiFuture<WriteResult> createFuture = documentReference.create(fields);
 
@@ -189,6 +190,23 @@ public class CollectionReference extends Query {
           }
         },
         MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Adds a new document to this collection with the specified POJO as contents, assigning it a
+   * document ID automatically.
+   *
+   * @param pojo The POJO that will be used to populate the contents of the document
+   * @return An ApiFuture that will be resolved with the DocumentReference of the newly created
+   *     document.
+   * @see #document()
+   */
+  public ApiFuture<DocumentReference> add(Object pojo) {
+    Object converted = CustomClassMapper.convertToPlainJavaTypes(pojo);
+    if (!(converted instanceof Map)) {
+      throw FirestoreException.invalidState("Can't set a document's data to an array or primitive");
+    }
+    return add((Map<String, Object>) converted);
   }
 
   /** Returns a resource path pointing to this collection. */

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
@@ -152,7 +152,7 @@ public class DocumentReference {
    * Creates a new Document at the DocumentReference location. It fails the write if the document
    * exists.
    *
-   * @param pojo A map of the fields and values for the document.
+   * @param pojo The POJO that will be used to populate the document contents.
    * @return An ApiFuture that will be resolved when the write finishes.
    */
   @Nonnull

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
@@ -136,10 +136,23 @@ public class DocumentReference {
   }
 
   /**
+   * Creates a new Document at the DocumentReference's Location. It fails the write if the document
+   * exists.
+   *
+   * @param fields A map of the fields and values for the document.
+   * @return An ApiFuture that will be resolved when the write finishes.
+   */
+  @Nonnull
+  public ApiFuture<WriteResult> create(@Nonnull Map<String, Object> fields) {
+    WriteBatch writeBatch = firestore.batch();
+    return extractFirst(writeBatch.create(this, fields).commit());
+  }
+
+  /**
    * Creates a new Document at the DocumentReference location. It fails the write if the document
    * exists.
    *
-   * @param pojo The Map or POJO that will be used to populate the document contents.
+   * @param pojo A map of the fields and values for the document.
    * @return An ApiFuture that will be resolved when the write finishes.
    */
   @Nonnull
@@ -152,12 +165,11 @@ public class DocumentReference {
    * Overwrites the document referred to by this DocumentReference. If no document exists yet, it
    * will be created. If a document already exists, it will be overwritten.
    *
-   * @param fields The fields to write to the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param fields A map of the fields and values for the document.
    * @return An ApiFuture that will be resolved when the write finishes.
    */
   @Nonnull
-  public ApiFuture<WriteResult> set(@Nonnull Object fields) {
+  public ApiFuture<WriteResult> set(@Nonnull Map<String, Object> fields) {
     WriteBatch writeBatch = firestore.batch();
     return extractFirst(writeBatch.set(this, fields).commit());
   }
@@ -167,15 +179,43 @@ public class DocumentReference {
    * exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged into
    * an existing document.
    *
-   * @param fields The fields to write on the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param fields A map of the fields and values for the document.
    * @param options An object to configure the set behavior.
    * @return An ApiFuture that will be resolved when the write finishes.
    */
   @Nonnull
-  public ApiFuture<WriteResult> set(@Nonnull Object fields, @Nonnull SetOptions options) {
+  public ApiFuture<WriteResult> set(
+      @Nonnull Map<String, Object> fields, @Nonnull SetOptions options) {
     WriteBatch writeBatch = firestore.batch();
     return extractFirst(writeBatch.set(this, fields, options).commit());
+  }
+
+  /**
+   * Overwrites the document referred to by this DocumentReference. If no document exists yet, it
+   * will be created. If a document already exists, it will be overwritten.
+   *
+   * @param pojo The POJO that will be used to populate the document contents.
+   * @return An ApiFuture that will be resolved when the write finishes.
+   */
+  @Nonnull
+  public ApiFuture<WriteResult> set(@Nonnull Object pojo) {
+    WriteBatch writeBatch = firestore.batch();
+    return extractFirst(writeBatch.set(this, pojo).commit());
+  }
+
+  /**
+   * Writes to the document referred to by this DocumentReference. If the document does not yet
+   * exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged into
+   * an existing document.
+   *
+   * @param pojo The POJO that will be used to populate the document contents.
+   * @param options An object to configure the set behavior.
+   * @return An ApiFuture that will be resolved when the write finishes.
+   */
+  @Nonnull
+  public ApiFuture<WriteResult> set(@Nonnull Object pojo, @Nonnull SetOptions options) {
+    WriteBatch writeBatch = firestore.batch();
+    return extractFirst(writeBatch.set(this, pojo, options).commit());
   }
 
   /**

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -105,16 +105,13 @@ public abstract class UpdateBuilder<T extends UpdateBuilder> {
    * exists.
    *
    * @param documentReference The DocumentReference to create.
-   * @param fields The Map or POJO that will be used to populate the document contents.
+   * @param fields A map of the fields and values for the document.
    * @return The instance for chaining.
    */
   @Nonnull
-  public T create(@Nonnull DocumentReference documentReference, @Nonnull Object fields) {
-    Object data = CustomClassMapper.convertToPlainJavaTypes(fields);
-    if (!(data instanceof Map)) {
-      FirestoreException.invalidState("Can't set a document's data to an array or primitive");
-    }
-    return performCreate(documentReference, (Map<String, Object>) data);
+  public T create(
+      @Nonnull DocumentReference documentReference, @Nonnull Map<String, Object> fields) {
+    return performCreate(documentReference, fields);
   }
 
   private T performCreate(
@@ -150,15 +147,32 @@ public abstract class UpdateBuilder<T extends UpdateBuilder> {
   }
 
   /**
+   * Creates a new Document at the DocumentReference location. It fails the write if the document
+   * exists.
+   *
+   * @param documentReference The DocumentReference to create.
+   * @param pojo A map of the fields and values for the document.
+   * @return The instance for chaining.
+   */
+  @Nonnull
+  public T create(@Nonnull DocumentReference documentReference, @Nonnull Object pojo) {
+    Object data = CustomClassMapper.convertToPlainJavaTypes(pojo);
+    if (!(data instanceof Map)) {
+      throw FirestoreException.invalidState("Can't set a document's data to an array or primitive");
+    }
+    return performCreate(documentReference, (Map<String, Object>) data);
+  }
+
+  /**
    * Overwrites the document referred to by this DocumentReference. If the document doesn't exist
    * yet, it will be created. If a document already exists, it will be overwritten.
    *
    * @param documentReference The DocumentReference to overwrite.
-   * @param fields The Map or POJO that will be used to populate the document contents.
+   * @param fields A map of the field paths and values for the document.
    * @return The instance for chaining.
    */
   @Nonnull
-  public T set(@Nonnull DocumentReference documentReference, @Nonnull Object fields) {
+  public T set(@Nonnull DocumentReference documentReference, @Nonnull Map<String, Object> fields) {
     return set(documentReference, fields, SetOptions.OVERWRITE);
   }
 
@@ -168,16 +182,47 @@ public abstract class UpdateBuilder<T extends UpdateBuilder> {
    * an existing document.
    *
    * @param documentReference The DocumentReference to overwrite.
-   * @param fields The Map or POJO that will be used to populate the document contents.
+   * @param fields A map of the field paths and values for the document.
    * @param options An object to configure the set behavior.
    * @return The instance for chaining.
    */
   @Nonnull
   public T set(
       @Nonnull DocumentReference documentReference,
-      @Nonnull Object fields,
+      @Nonnull Map<String, Object> fields,
       @Nonnull SetOptions options) {
-    Object data = CustomClassMapper.convertToPlainJavaTypes(fields);
+    return performSet(documentReference, fields, options);
+  }
+
+  /**
+   * Overwrites the document referred to by this DocumentReference. If the document doesn't exist
+   * yet, it will be created. If a document already exists, it will be overwritten.
+   *
+   * @param documentReference The DocumentReference to overwrite.
+   * @param pojo The POJO that will be used to populate the document contents.
+   * @return The instance for chaining.
+   */
+  @Nonnull
+  public T set(@Nonnull DocumentReference documentReference, @Nonnull Object pojo) {
+    return set(documentReference, pojo, SetOptions.OVERWRITE);
+  }
+
+  /**
+   * Overwrites the document referred to by this DocumentReference. If the document doesn't exist
+   * yet, it will be created. If you pass {@link SetOptions}, the provided data can be merged into
+   * an existing document.
+   *
+   * @param documentReference The DocumentReference to overwrite.
+   * @param pojo The POJO that will be used to populate the document contents.
+   * @param options An object to configure the set behavior.
+   * @return The instance for chaining.
+   */
+  @Nonnull
+  public T set(
+      @Nonnull DocumentReference documentReference,
+      @Nonnull Object pojo,
+      @Nonnull SetOptions options) {
+    Object data = CustomClassMapper.convertToPlainJavaTypes(pojo);
     if (!(data instanceof Map)) {
       throw new IllegalArgumentException("Can't set a document's data to an array or primitive");
     }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -151,7 +151,7 @@ public abstract class UpdateBuilder<T extends UpdateBuilder> {
    * exists.
    *
    * @param documentReference The DocumentReference to create.
-   * @param pojo A map of the fields and values for the document.
+   * @param pojo The POJO that will be used to populate the document contents.
    * @return The instance for chaining.
    */
   @Nonnull


### PR DESCRIPTION
Methods in CollectionReference, DocumentReference and UpdateBuilder need to keep their `Map<String, Object>` variants to preserve binary compatibility with any project that was compiled against a version of google-cloud-firestore prior to this change.

Original feature commit: 180f5a96