### PR TITLE
build: exclude animal-sniffer-annotations from grpc-api

### DIFF
--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -92,6 +92,14 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <exclusions>
+        <!-- currently collides with animal-sniffer-annotations from guava -->
+        <!-- TODO(#33) try to remove after the next bump of guava -->
+        <exclusion>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>

--- a/grpc-google-cloud-firestore-admin-v1/pom.xml
+++ b/grpc-google-cloud-firestore-admin-v1/pom.xml
@@ -35,6 +35,14 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
+            <exclusions>
+                <!-- currently collides with animal-sniffer-annotations from guava -->
+                <!-- TODO(#33) try to remove after the next bump of guava -->
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/grpc-google-cloud-firestore-v1/pom.xml
+++ b/grpc-google-cloud-firestore-v1/pom.xml
@@ -31,6 +31,14 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
+            <exclusions>
+                <!-- currently collides with animal-sniffer-annotations from guava -->
+                <!-- TODO(#33) try to remove after the next bump of guava -->
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/grpc-google-cloud-firestore-v1beta1/pom.xml
+++ b/grpc-google-cloud-firestore-v1beta1/pom.xml
@@ -31,6 +31,14 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
+      <exclusions>
+        <!-- currently collides with animal-sniffer-annotations from guava -->
+        <!-- TODO(#33) try to remove after the next bump of guava -->
+        <exclusion>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Temporary workaround for #33
