### PR TITLE
build: update annotationProcessorPaths to include auto-service-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,20 +327,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.auto.value</groupId>
-              <artifactId>auto-value</artifactId>
-              <version>${auto-value.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 
   <modules>
@@ -364,6 +350,29 @@
         <auto-value-annotation.version>1.6.6</auto-value-annotation.version>
         <auto-value.version>1.4</auto-value.version>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.auto.value</groupId>
+                  <artifactId>auto-value</artifactId>
+                  <version>${auto-value.version}</version>
+                </path>
+                <!--
+                There is currently no available version of auto-service-annotations
+                in maven central compiled for java 1.7 so we can't include it here.
+
+                If you're using IntelliJ please use a newer jdk and set the language
+                level to 1.7 for your dev work.
+                -->
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -374,7 +383,45 @@
       <properties>
         <auto-value.version>1.6.6</auto-value.version>
         <auto-value-annotation.version>${auto-value.version}</auto-value-annotation.version>
+        <auto-service-annotations.version>1.0-rc5</auto-service-annotations.version>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.auto.value</groupId>
+                  <artifactId>auto-value</artifactId>
+                  <version>${auto-value.version}</version>
+                </path>
+                <!--
+                Manually pull in auto-service-annotations so that it is part of the
+                processor path because auto-value has it set to provided scope.
+
+                This dependency is needed due to the retention change in
+                https://github.com/google/auto/commit/628df548685b4fc0f2a9af856f97cc2a68da246b
+                where the RetentionPolicy changed from SOURCE to CLASS.
+
+                Due to the RetentionPolicy change to CLASS we must have the
+                annotations available on the processor path otherwise the following
+                will error will be thrown. (This is a particular problem with the
+                annotation processor configuration in IntelliJ)
+
+                Error:java: java.lang.NoClassDefFoundError: com/google/auto/service/AutoService
+                  com.google.auto.service.AutoService
+                -->
+                <path>
+                  <groupId>com.google.auto.service</groupId>
+                  <artifactId>auto-service-annotations</artifactId>
+                  <version>${auto-service-annotations.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
         <jdk>1.7</jdk>
       </activation>
       <properties>
-        <auto-value-annotation.version>1.6.6</auto-value-annotation.version>
+        <auto-value-annotation.version>1.7</auto-value-annotation.version>
         <auto-value.version>1.4</auto-value.version>
       </properties>
       <build>
@@ -381,7 +381,7 @@
         <jdk>[1.8,)</jdk>
       </activation>
       <properties>
-        <auto-value.version>1.6.6</auto-value.version>
+        <auto-value.version>1.7</auto-value.version>
         <auto-value-annotation.version>${auto-value.version}</auto-value-annotation.version>
         <auto-service-annotations.version>1.0-rc5</auto-service-annotations.version>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
       <properties>
         <auto-value.version>1.7</auto-value.version>
         <auto-value-annotation.version>${auto-value.version}</auto-value-annotation.version>
-        <auto-service-annotations.version>1.0-rc5</auto-service-annotations.version>
+        <auto-service-annotations.version>1.0-rc6</auto-service-annotations.version>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
With the recent bump to auto-value-annotations 1.7 IntelliJ is not longer
able to build the project due to a NoClassDefFoundError.

Here we manually pull in auto-service-annotations so that it is part of the
processor path because auto-value has it set to provided scope.

This dependency is needed due to the retention change in
https://github.com/google/auto/commit/628df548685b4fc0f2a9af856f97cc2a68da246b
where the RetentionPolicy changed from SOURCE to CLASS.

Due to the RetentionPolicy change to CLASS we must have the
annotations available on the processor path otherwise the following
will error will be thrown. (This is a particular problem with the
annotation processor configuration in IntelliJ)

Error:java: java.lang.NoClassDefFoundError: com/google/auto/service/AutoService
com.google.auto.service.AutoService
