### PR TITLE
fix: deflake-ify ITSystemTest#queryWatch

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -385,6 +385,8 @@ public final class ITQueryWatchTest {
 
   private static final class EventsCountDownLatch {
     private final CountDownLatch initialEventsCountDownLatch;
+    private final int initialEventCount;
+    private final EnumMap<DocumentChange.Type, Integer> eventsCounts;
     private final EnumMap<DocumentChange.Type, CountDownLatch> eventsCountDownLatches;
 
     EventsCountDownLatch(
@@ -393,6 +395,11 @@ public final class ITQueryWatchTest {
         int modifiedInitialCount,
         int removedInitialCount) {
       initialEventsCountDownLatch = new CountDownLatch(initialEventCount);
+      this.initialEventCount = initialEventCount;
+      eventsCounts = new EnumMap<>(DocumentChange.Type.class);
+      eventsCounts.put(DocumentChange.Type.ADDED, addedInitialCount);
+      eventsCounts.put(DocumentChange.Type.MODIFIED, modifiedInitialCount);
+      eventsCounts.put(DocumentChange.Type.REMOVED, removedInitialCount);
       eventsCountDownLatches = new EnumMap<>(DocumentChange.Type.class);
       eventsCountDownLatches.put(DocumentChange.Type.ADDED, new CountDownLatch(addedInitialCount));
       eventsCountDownLatches.put(
@@ -410,11 +417,12 @@ public final class ITQueryWatchTest {
     }
 
     void awaitInitialEvents() throws InterruptedException {
-      initialEventsCountDownLatch.await(5, TimeUnit.SECONDS);
+      initialEventsCountDownLatch.await(5 * initialEventCount, TimeUnit.SECONDS);
     }
 
     void await(DocumentChange.Type type) throws InterruptedException {
-      eventsCountDownLatches.get(type).await(5, TimeUnit.SECONDS);
+      int count = eventsCounts.get(type);
+      eventsCountDownLatches.get(type).await(5 * count, TimeUnit.SECONDS);
     }
   }
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -87,9 +87,13 @@ public final class ITQueryWatchTest {
     firestore.close();
   }
 
-  /*
-  Attach a listener to a query with empty results.
-  Verify the listener receives an empty event.
+  /**
+   *
+   *
+   * <ol>
+   *   <li>Attach a listener to a query with empty results.
+   *   <li>Verify the listener receives an empty event.
+   * </ol>
    */
   @Test
   public void emptyResults() throws InterruptedException {
@@ -112,9 +116,13 @@ public final class ITQueryWatchTest {
     listenerAssertions.removedIdsIsAnyOf(emptySet());
   }
 
-  /*
-  Attach a listener to a query with non-empty results.
-  Verify the listener receives an event including the expected document.
+  /**
+   *
+   *
+   * <ol>
+   *   <li>Attach a listener to a query with non-empty results.
+   *   <li>Verify the listener receives an event including the expected document.
+   * </ol>
    */
   @Test
   public void nonEmptyResults() throws InterruptedException, TimeoutException, ExecutionException {
@@ -139,11 +147,15 @@ public final class ITQueryWatchTest {
     listenerAssertions.removedIdsIsAnyOf(emptySet());
   }
 
-  /*
-  Attach a listener to a query with empty results.
-  Create a new document that matches the query.
-  Verify newly created document results in an ADDED event.
-  */
+  /**
+   *
+   *
+   * <ol>
+   *   <li>Attach a listener to a query with empty results.
+   *   <li>Create a new document that matches the query.
+   *   <li>Verify newly created document results in an ADDED event.
+   * </ol>
+   */
   @Test
   public void emptyResults_newDocument_ADDED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -168,11 +180,15 @@ public final class ITQueryWatchTest {
     listenerAssertions.removedIdsIsAnyOf(emptySet());
   }
 
-  /*
-  Attach a listener to a query with empty results.
-  Modify an existing document so that it matches the query.
-  Verify newly created document results in an ADDED event.
-  */
+  /**
+   *
+   *
+   * <ol>
+   *   <li>Attach a listener to a query with empty results.
+   *   <li>Modify an existing document so that it matches the query.
+   *   <li>Verify newly created document results in an ADDED event.
+   * </ol>
+   */
   @Test
   public void emptyResults_modifiedDocument_ADDED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -206,11 +222,15 @@ public final class ITQueryWatchTest {
     assertThat(doc.get("baz")).isEqualTo("baz");
   }
 
-  /*
-  Attach a listener to a query with non-empty results.
-  Modify an existing document that is part of the results.
-  Verify modified document results in a MODIFIED event.
-  */
+  /**
+   *
+   *
+   * <ol>
+   *   <li>Attach a listener to a query with non-empty results.
+   *   <li>Modify an existing document that is part of the results.
+   *   <li>Verify modified document results in a MODIFIED event.
+   * </ol>
+   */
   @Test
   public void nonEmptyResults_modifiedDocument_MODIFIED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -246,11 +266,15 @@ public final class ITQueryWatchTest {
     assertThat(doc.get("baz")).isEqualTo("baz");
   }
 
-  /*
-  Attach a listener to a query with non-empty results.
-  Delete an existing document that is part of the results.
-  Verify deleted document results in a REMOVED event.
-  */
+  /**
+   *
+   *
+   * <ol>
+   *   <li>Attach a listener to a query with non-empty results.
+   *   <li>Delete an existing document that is part of the results.
+   *   <li>Verify deleted document results in a REMOVED event.
+   * </ol>
+   */
   @Test
   public void nonEmptyResults_deletedDocument_REMOVED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -285,11 +309,15 @@ public final class ITQueryWatchTest {
     assertThat(doc.get("foo")).isEqualTo("bar");
   }
 
-  /*
-  Attach a listener to a query with non-empty results.
-  Modify an existing document that is part of the results to no longer match the query.
-  Verify modified document results in a REMOVED event.
-  */
+  /**
+   *
+   *
+   * <ol>
+   *   <li>Attach a listener to a query with non-empty results.
+   *   <li>Modify an existing document that is part of the results to no longer match the query.
+   *   <li>Verify modified document results in a REMOVED event.
+   * </ol>
+   */
   @Test
   public void nonEmptyResults_modifiedDocument_REMOVED()
       throws InterruptedException, TimeoutException, ExecutionException {

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -102,9 +102,9 @@ public final class ITQueryWatchTest {
     }
 
     assertThat(listener.receivedEvents).hasSize(1);
-    ListenerEvent e = listener.receivedEvents.get(0);
-    assertThat(e.error).isNull();
-    QuerySnapshot snap = e.value;
+    ListenerEvent event = listener.receivedEvents.get(0);
+    assertThat(event.error).isNull();
+    QuerySnapshot snap = event.value;
     assertThat(snap).isNotNull();
     assertThat(snap).isEmpty();
     assertThat(snap.getDocumentChanges()).isEmpty();
@@ -131,9 +131,9 @@ public final class ITQueryWatchTest {
     }
 
     assertThat(receivedEvents).hasSize(1);
-    ListenerEvent e = receivedEvents.get(0);
-    assertThat(e.error).isNull();
-    QuerySnapshot snap = e.value;
+    ListenerEvent event = receivedEvents.get(0);
+    assertThat(event.error).isNull();
+    QuerySnapshot snap = event.value;
     assertThat(snap).isNotNull();
     assertThat(snap).hasSize(1);
   }
@@ -196,9 +196,9 @@ public final class ITQueryWatchTest {
     la.modifiedIdsIsAnyOf(emptySet());
     la.removedIdsIsAnyOf(emptySet());
 
-    ListenerEvent e = receivedEvents.get(receivedEvents.size() - 1);
+    ListenerEvent event = receivedEvents.get(receivedEvents.size() - 1);
     //noinspection ConstantConditions guarded by "assertNoError" above
-    QueryDocumentSnapshot doc = e.value.getDocumentChanges().get(0).getDocument();
+    QueryDocumentSnapshot doc = event.value.getDocumentChanges().get(0).getDocument();
     assertThat(doc.get("foo")).isEqualTo("bar");
     assertThat(doc.get("baz")).isEqualTo("baz");
   }
@@ -236,9 +236,9 @@ public final class ITQueryWatchTest {
     la.modifiedIdsIsAnyOf(emptySet(), newHashSet("doc"));
     la.removedIdsIsAnyOf(emptySet());
 
-    ListenerEvent e = receivedEvents.get(receivedEvents.size() - 1);
+    ListenerEvent event = receivedEvents.get(receivedEvents.size() - 1);
     //noinspection ConstantConditions guarded by "assertNoError" above
-    QueryDocumentSnapshot doc = e.value.getDocumentChanges().get(0).getDocument();
+    QueryDocumentSnapshot doc = event.value.getDocumentChanges().get(0).getDocument();
     assertThat(doc.get("foo")).isEqualTo("bar");
     assertThat(doc.get("baz")).isEqualTo("baz");
   }
@@ -276,9 +276,9 @@ public final class ITQueryWatchTest {
     la.modifiedIdsIsAnyOf(emptySet());
     la.removedIdsIsAnyOf(emptySet(), newHashSet("doc"));
 
-    ListenerEvent e = receivedEvents.get(receivedEvents.size() - 1);
+    ListenerEvent event = receivedEvents.get(receivedEvents.size() - 1);
     //noinspection ConstantConditions guarded by "assertNoError" above
-    QueryDocumentSnapshot doc = e.value.getDocumentChanges().get(0).getDocument();
+    QueryDocumentSnapshot doc = event.value.getDocumentChanges().get(0).getDocument();
     assertThat(doc.get("foo")).isEqualTo("bar");
   }
 
@@ -315,9 +315,9 @@ public final class ITQueryWatchTest {
     la.modifiedIdsIsAnyOf(emptySet());
     la.removedIdsIsAnyOf(emptySet(), newHashSet("doc"));
 
-    ListenerEvent e = receivedEvents.get(receivedEvents.size() - 1);
+    ListenerEvent event = receivedEvents.get(receivedEvents.size() - 1);
     //noinspection ConstantConditions guarded by "assertNoError" above
-    QueryDocumentSnapshot doc = e.value.getDocumentChanges().get(0).getDocument();
+    QueryDocumentSnapshot doc = event.value.getDocumentChanges().get(0).getDocument();
     assertThat(doc.get("foo")).isEqualTo("bar");
   }
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -101,13 +101,12 @@ public final class ITQueryWatchTest {
       registration.remove();
     }
 
-    assertThat(listener.receivedEvents).hasSize(1);
-    ListenerEvent event = listener.receivedEvents.get(0);
-    assertThat(event.error).isNull();
-    QuerySnapshot snap = event.value;
-    assertThat(snap).isNotNull();
-    assertThat(snap).isEmpty();
-    assertThat(snap.getDocumentChanges()).isEmpty();
+    ListenerAssertions la = listener.assertions();
+    la.noError();
+    la.eventCountIsAnyOf(Range.closed(1, 1));
+    la.addedIdsIsAnyOf(emptySet());
+    la.modifiedIdsIsAnyOf(emptySet());
+    la.removedIdsIsAnyOf(emptySet());
   }
 
   /*
@@ -121,7 +120,6 @@ public final class ITQueryWatchTest {
 
     final Query query = randomColl.whereEqualTo("foo", "bar");
     QuerySnapshotEventListener listener = new QuerySnapshotEventListener(1);
-    List<ListenerEvent> receivedEvents = listener.receivedEvents;
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
@@ -130,12 +128,12 @@ public final class ITQueryWatchTest {
       registration.remove();
     }
 
-    assertThat(receivedEvents).hasSize(1);
-    ListenerEvent event = receivedEvents.get(0);
-    assertThat(event.error).isNull();
-    QuerySnapshot snap = event.value;
-    assertThat(snap).isNotNull();
-    assertThat(snap).hasSize(1);
+    ListenerAssertions la = listener.assertions();
+    la.noError();
+    la.eventCountIsAnyOf(Range.closed(1, 1));
+    la.addedIdsIsAnyOf(newHashSet("doc"));
+    la.modifiedIdsIsAnyOf(emptySet());
+    la.removedIdsIsAnyOf(emptySet());
   }
 
   /*
@@ -399,6 +397,7 @@ public final class ITQueryWatchTest {
     }
 
     static final class ListenerAssertions {
+      private static final MapJoiner MAP_JOINER = Joiner.on(",").withKeyValueSeparator("=");
       final List<ListenerEvent> receivedEvents;
       private final FluentIterable<ListenerEvent> events;
       private final Set<String> addedIds;

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -85,7 +85,8 @@ public final class ITQueryWatchTest {
   }
 
   /*
-  Start a listener on a query with an empty result set
+  Attach a listener to a query with empty results.
+  Verify the listener receives an empty event.
    */
   @Test
   public void emptyResults() throws InterruptedException {
@@ -110,14 +111,14 @@ public final class ITQueryWatchTest {
   }
 
   /*
-  Start a listener on a query with a non-empty result set
+  Attach a listener to a query with non-empty results.
+  Verify the listener receives an event including the expected document.
    */
   @Test
   public void nonEmptyResults() throws InterruptedException, TimeoutException, ExecutionException {
     // create a document in our collection that will match the query
     randomColl.document("doc").set(map("foo", "bar")).get(5, TimeUnit.SECONDS);
 
-    // run our test
     final Query query = randomColl.whereEqualTo("foo", "bar");
     QuerySnapshotEventListener listener = new QuerySnapshotEventListener(1);
     List<ListenerEvent> receivedEvents = listener.receivedEvents;
@@ -138,14 +139,14 @@ public final class ITQueryWatchTest {
   }
 
   /*
-  Starting from a query with empty results creating a new document
-  that matches the query should result in an ADDED event
+   Attach a listener to a query with empty results.
+   Create a new document that matches the query.
+   Verify newly created document results in an ADDED event.
    */
   @Test
   public void emptyResults_newDocument_ADDED()
       throws InterruptedException, TimeoutException, ExecutionException {
 
-    // run our test
     final Query query = randomColl.whereEqualTo("foo", "bar");
     QuerySnapshotEventListener listener = new QuerySnapshotEventListener(1, 1, 0, 0);
     ListenerRegistration registration = query.addSnapshotListener(listener);
@@ -166,8 +167,9 @@ public final class ITQueryWatchTest {
   }
 
   /*
-  Starting from a query with empty results, modifying an existing document to
-  match the query should result in an ADDED event
+   Attach a listener to a query with empty results.
+   Modify an existing document so that it matches the query.
+   Verify newly created document results in an ADDED event.
    */
   @Test
   public void emptyResults_modifiedDocument_ADDED()
@@ -175,7 +177,6 @@ public final class ITQueryWatchTest {
     // create our "existing non-matching document"
     randomColl.document("doc").set(map("baz", "baz")).get(5, TimeUnit.SECONDS);
 
-    // run our test
     final Query query = randomColl.whereEqualTo("foo", "bar");
     QuerySnapshotEventListener listener = new QuerySnapshotEventListener(1, 1, 0, 0);
     List<ListenerEvent> receivedEvents = listener.receivedEvents;
@@ -203,8 +204,9 @@ public final class ITQueryWatchTest {
   }
 
   /*
-  Starting from a query with non-empty results, modifying an existing document which matches
-  the query should result in a MODIFIED event
+   Attach a listener to a query with non-empty results.
+   Modify an existing document that is part of the results.
+   Verify modified document results in a MODIFIED event.
    */
   @Test
   public void nonEmptyResults_modifiedDocument_MODIFIED()
@@ -213,7 +215,6 @@ public final class ITQueryWatchTest {
     // create our "existing non-matching document"
     testDoc.set(map("foo", "bar")).get(5, TimeUnit.SECONDS);
 
-    // run our test
     final Query query = randomColl.whereEqualTo("foo", "bar");
     // register the snapshot listener for the query
     QuerySnapshotEventListener listener = new QuerySnapshotEventListener(1, 0, 1, 0);
@@ -243,8 +244,9 @@ public final class ITQueryWatchTest {
   }
 
   /*
-  Starting from a query with non-empty results, deleting an existing document which matches
-  the query should result in a REMOVED event
+   Attach a listener to a query with non-empty results.
+   Delete an existing document that is part of the results.
+   Verify deleted document results in a REMOVED event.
    */
   @Test
   public void nonEmptyResults_deletedDocument_REMOVED()
@@ -253,7 +255,6 @@ public final class ITQueryWatchTest {
     // create our "existing non-matching document"
     testDoc.set(map("foo", "bar")).get(5, TimeUnit.SECONDS);
 
-    // run our test
     final Query query = randomColl.whereEqualTo("foo", "bar");
     // register the snapshot listener for the query
     QuerySnapshotEventListener listener = new QuerySnapshotEventListener(1, 0, 0, 1);
@@ -282,8 +283,9 @@ public final class ITQueryWatchTest {
   }
 
   /*
-  Starting from a query with non-empty results, modifying an existing document which matches
-  the query such that it no longer matches the query should result in a REMOVED event
+   Attach a listener to a query with non-empty results.
+   Modify an existing document that is part of the results to no longer match the query.
+   Verify modified document results in a REMOVED event.
    */
   @Test
   public void nonEmptyResults_modifiedDocument_REMOVED()
@@ -292,7 +294,6 @@ public final class ITQueryWatchTest {
     // create our "existing non-matching document"
     testDoc.set(map("foo", "bar")).get(5, TimeUnit.SECONDS);
 
-    // run our test
     final Query query = randomColl.whereEqualTo("foo", "bar");
     // register the snapshot listener for the query
     QuerySnapshotEventListener listener = new QuerySnapshotEventListener(1, 0, 0, 1);

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -99,17 +99,17 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
-      listener.eventsCountDownLatch.await();
+      listener.eventsCountDownLatch.awaitInitialEvents();
     } finally {
       registration.remove();
     }
 
-    ListenerAssertions la = listener.assertions();
-    la.noError();
-    la.eventCountIsAnyOf(Range.closed(1, 1));
-    la.addedIdsIsAnyOf(emptySet());
-    la.modifiedIdsIsAnyOf(emptySet());
-    la.removedIdsIsAnyOf(emptySet());
+    ListenerAssertions listenerAssertions = listener.assertions();
+    listenerAssertions.noError();
+    listenerAssertions.eventCountIsAnyOf(Range.closed(1, 1));
+    listenerAssertions.addedIdsIsAnyOf(emptySet());
+    listenerAssertions.modifiedIdsIsAnyOf(emptySet());
+    listenerAssertions.removedIdsIsAnyOf(emptySet());
   }
 
   /*
@@ -126,17 +126,17 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
-      listener.eventsCountDownLatch.await();
+      listener.eventsCountDownLatch.awaitInitialEvents();
     } finally {
       registration.remove();
     }
 
-    ListenerAssertions la = listener.assertions();
-    la.noError();
-    la.eventCountIsAnyOf(Range.closed(1, 1));
-    la.addedIdsIsAnyOf(newHashSet("doc"));
-    la.modifiedIdsIsAnyOf(emptySet());
-    la.removedIdsIsAnyOf(emptySet());
+    ListenerAssertions listenerAssertions = listener.assertions();
+    listenerAssertions.noError();
+    listenerAssertions.eventCountIsAnyOf(Range.closed(1, 1));
+    listenerAssertions.addedIdsIsAnyOf(newHashSet("doc"));
+    listenerAssertions.modifiedIdsIsAnyOf(emptySet());
+    listenerAssertions.removedIdsIsAnyOf(emptySet());
   }
 
   /*
@@ -153,19 +153,19 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
-      listener.eventsCountDownLatch.await();
+      listener.eventsCountDownLatch.awaitInitialEvents();
       randomColl.document("doc").set(map("foo", "bar")).get(5, TimeUnit.SECONDS);
       listener.eventsCountDownLatch.await(DocumentChange.Type.ADDED);
     } finally {
       registration.remove();
     }
 
-    ListenerAssertions la = listener.assertions();
-    la.noError();
-    la.eventCountIsAnyOf(Range.closed(2, 2));
-    la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
-    la.modifiedIdsIsAnyOf(emptySet());
-    la.removedIdsIsAnyOf(emptySet());
+    ListenerAssertions listenerAssertions = listener.assertions();
+    listenerAssertions.noError();
+    listenerAssertions.eventCountIsAnyOf(Range.closed(2, 2));
+    listenerAssertions.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
+    listenerAssertions.modifiedIdsIsAnyOf(emptySet());
+    listenerAssertions.removedIdsIsAnyOf(emptySet());
   }
 
   /*
@@ -185,19 +185,19 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
-      listener.eventsCountDownLatch.await();
+      listener.eventsCountDownLatch.awaitInitialEvents();
       randomColl.document("doc").update("foo", "bar").get(5, TimeUnit.SECONDS);
       listener.eventsCountDownLatch.await(DocumentChange.Type.ADDED);
     } finally {
       registration.remove();
     }
 
-    ListenerAssertions la = listener.assertions();
-    la.noError();
-    la.eventCountIsAnyOf(Range.closed(2, 2));
-    la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
-    la.modifiedIdsIsAnyOf(emptySet());
-    la.removedIdsIsAnyOf(emptySet());
+    ListenerAssertions listenerAssertions = listener.assertions();
+    listenerAssertions.noError();
+    listenerAssertions.eventCountIsAnyOf(Range.closed(2, 2));
+    listenerAssertions.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
+    listenerAssertions.modifiedIdsIsAnyOf(emptySet());
+    listenerAssertions.removedIdsIsAnyOf(emptySet());
 
     ListenerEvent event = receivedEvents.get(receivedEvents.size() - 1);
     //noinspection ConstantConditions guarded by "assertNoError" above
@@ -225,19 +225,19 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
-      listener.eventsCountDownLatch.await();
+      listener.eventsCountDownLatch.awaitInitialEvents();
       testDoc.update("baz", "baz").get(5, TimeUnit.SECONDS);
       listener.eventsCountDownLatch.await(DocumentChange.Type.MODIFIED);
     } finally {
       registration.remove();
     }
 
-    ListenerAssertions la = listener.assertions();
-    la.noError();
-    la.eventCountIsAnyOf(Range.closed(2, 2));
-    la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
-    la.modifiedIdsIsAnyOf(emptySet(), newHashSet("doc"));
-    la.removedIdsIsAnyOf(emptySet());
+    ListenerAssertions listenerAssertions = listener.assertions();
+    listenerAssertions.noError();
+    listenerAssertions.eventCountIsAnyOf(Range.closed(2, 2));
+    listenerAssertions.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
+    listenerAssertions.modifiedIdsIsAnyOf(emptySet(), newHashSet("doc"));
+    listenerAssertions.removedIdsIsAnyOf(emptySet());
 
     ListenerEvent event = receivedEvents.get(receivedEvents.size() - 1);
     //noinspection ConstantConditions guarded by "assertNoError" above
@@ -265,19 +265,19 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
-      listener.eventsCountDownLatch.await();
+      listener.eventsCountDownLatch.awaitInitialEvents();
       testDoc.delete().get(5, TimeUnit.SECONDS);
       listener.eventsCountDownLatch.await(DocumentChange.Type.REMOVED);
     } finally {
       registration.remove();
     }
 
-    ListenerAssertions la = listener.assertions();
-    la.noError();
-    la.eventCountIsAnyOf(Range.closed(2, 2));
-    la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
-    la.modifiedIdsIsAnyOf(emptySet());
-    la.removedIdsIsAnyOf(emptySet(), newHashSet("doc"));
+    ListenerAssertions listenerAssertions = listener.assertions();
+    listenerAssertions.noError();
+    listenerAssertions.eventCountIsAnyOf(Range.closed(2, 2));
+    listenerAssertions.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
+    listenerAssertions.modifiedIdsIsAnyOf(emptySet());
+    listenerAssertions.removedIdsIsAnyOf(emptySet(), newHashSet("doc"));
 
     ListenerEvent event = receivedEvents.get(receivedEvents.size() - 1);
     //noinspection ConstantConditions guarded by "assertNoError" above
@@ -304,19 +304,19 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
-      listener.eventsCountDownLatch.await();
+      listener.eventsCountDownLatch.awaitInitialEvents();
       testDoc.set(map("bar", "foo")).get(5, TimeUnit.SECONDS);
       listener.eventsCountDownLatch.await(DocumentChange.Type.REMOVED);
     } finally {
       registration.remove();
     }
 
-    ListenerAssertions la = listener.assertions();
-    la.noError();
-    la.eventCountIsAnyOf(Range.closed(2, 2));
-    la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
-    la.modifiedIdsIsAnyOf(emptySet());
-    la.removedIdsIsAnyOf(emptySet(), newHashSet("doc"));
+    ListenerAssertions listenerAssertions = listener.assertions();
+    listenerAssertions.noError();
+    listenerAssertions.eventCountIsAnyOf(Range.closed(2, 2));
+    listenerAssertions.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
+    listenerAssertions.modifiedIdsIsAnyOf(emptySet());
+    listenerAssertions.removedIdsIsAnyOf(emptySet(), newHashSet("doc"));
 
     ListenerEvent event = receivedEvents.get(receivedEvents.size() - 1);
     //noinspection ConstantConditions guarded by "assertNoError" above
@@ -340,32 +340,37 @@ public final class ITQueryWatchTest {
   }
 
   private static final class EventsCountDownLatch {
-    private final CountDownLatch cdl;
-    private final EnumMap<DocumentChange.Type, CountDownLatch> cdls;
+    private final CountDownLatch initialEventsCountDownLatch;
+    private final EnumMap<DocumentChange.Type, CountDownLatch> eventsCountDownLatches;
 
     EventsCountDownLatch(
-        int nonChangeInitial, int addedInitial, int modifiedInitial, int removedInitial) {
-      cdl = new CountDownLatch(nonChangeInitial);
-      cdls = new EnumMap<>(DocumentChange.Type.class);
-      cdls.put(DocumentChange.Type.ADDED, new CountDownLatch(addedInitial));
-      cdls.put(DocumentChange.Type.MODIFIED, new CountDownLatch(modifiedInitial));
-      cdls.put(DocumentChange.Type.REMOVED, new CountDownLatch(removedInitial));
+        int initialEventCount,
+        int addedInitialCount,
+        int modifiedInitialCount,
+        int removedInitialCount) {
+      initialEventsCountDownLatch = new CountDownLatch(initialEventCount);
+      eventsCountDownLatches = new EnumMap<>(DocumentChange.Type.class);
+      eventsCountDownLatches.put(DocumentChange.Type.ADDED, new CountDownLatch(addedInitialCount));
+      eventsCountDownLatches.put(
+          DocumentChange.Type.MODIFIED, new CountDownLatch(modifiedInitialCount));
+      eventsCountDownLatches.put(
+          DocumentChange.Type.REMOVED, new CountDownLatch(removedInitialCount));
     }
 
     void countDown() {
-      cdl.countDown();
+      initialEventsCountDownLatch.countDown();
     }
 
     void countDown(DocumentChange.Type type) {
-      cdls.get(type).countDown();
+      eventsCountDownLatches.get(type).countDown();
     }
 
-    void await() throws InterruptedException {
-      cdl.await(5, TimeUnit.SECONDS);
+    void awaitInitialEvents() throws InterruptedException {
+      initialEventsCountDownLatch.await(5, TimeUnit.SECONDS);
     }
 
     void await(DocumentChange.Type type) throws InterruptedException {
-      cdls.get(type).await(5, TimeUnit.SECONDS);
+      eventsCountDownLatches.get(type).await(5, TimeUnit.SECONDS);
     }
   }
 
@@ -389,8 +394,8 @@ public final class ITQueryWatchTest {
       receivedEvents.add(new ListenerEvent(value, error));
       if (value != null) {
         List<DocumentChange> documentChanges = value.getDocumentChanges();
-        for (DocumentChange dc : documentChanges) {
-          eventsCountDownLatch.countDown(dc.getType());
+        for (DocumentChange docChange : documentChanges) {
+          eventsCountDownLatch.countDown(docChange.getType());
         }
       }
       eventsCountDownLatch.countDown();

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -407,14 +407,12 @@ public final class ITQueryWatchTest {
 
     static final class ListenerAssertions {
       private static final MapJoiner MAP_JOINER = Joiner.on(",").withKeyValueSeparator("=");
-      final List<ListenerEvent> receivedEvents;
       private final FluentIterable<ListenerEvent> events;
       private final Set<String> addedIds;
       private final Set<String> modifiedIds;
       private final Set<String> removedIds;
 
       ListenerAssertions(List<ListenerEvent> receivedEvents) {
-        this.receivedEvents = receivedEvents;
         events = FluentIterable.from(receivedEvents);
         List<QuerySnapshot> querySnapshots = getQuerySnapshots(events);
         addedIds = getIds(querySnapshots, DocumentChange.Type.ADDED);
@@ -492,13 +490,13 @@ public final class ITQueryWatchTest {
       }
 
       void eventCountIsAnyOf(Range<Integer> range) {
-        Truth.assertWithMessage(debugMessage()).that(receivedEvents.size()).isIn(range);
+        Truth.assertWithMessage(debugMessage()).that(events.size()).isIn(range);
       }
 
       private String debugMessage() {
         final StringBuilder builder = new StringBuilder();
         builder.append("events[\n");
-        for (ListenerEvent receivedEvent : receivedEvents) {
+        for (ListenerEvent receivedEvent : events) {
           builder.append("event{");
           builder.append("error=").append(receivedEvent.error);
           builder.append(",");

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.firestore.it;
 
 import static com.google.cloud.firestore.LocalFirestoreHelper.map;

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -140,10 +140,10 @@ public final class ITQueryWatchTest {
   }
 
   /*
-   Attach a listener to a query with empty results.
-   Create a new document that matches the query.
-   Verify newly created document results in an ADDED event.
-   */
+  Attach a listener to a query with empty results.
+  Create a new document that matches the query.
+  Verify newly created document results in an ADDED event.
+  */
   @Test
   public void emptyResults_newDocument_ADDED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -169,10 +169,10 @@ public final class ITQueryWatchTest {
   }
 
   /*
-   Attach a listener to a query with empty results.
-   Modify an existing document so that it matches the query.
-   Verify newly created document results in an ADDED event.
-   */
+  Attach a listener to a query with empty results.
+  Modify an existing document so that it matches the query.
+  Verify newly created document results in an ADDED event.
+  */
   @Test
   public void emptyResults_modifiedDocument_ADDED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -207,10 +207,10 @@ public final class ITQueryWatchTest {
   }
 
   /*
-   Attach a listener to a query with non-empty results.
-   Modify an existing document that is part of the results.
-   Verify modified document results in a MODIFIED event.
-   */
+  Attach a listener to a query with non-empty results.
+  Modify an existing document that is part of the results.
+  Verify modified document results in a MODIFIED event.
+  */
   @Test
   public void nonEmptyResults_modifiedDocument_MODIFIED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -247,10 +247,10 @@ public final class ITQueryWatchTest {
   }
 
   /*
-   Attach a listener to a query with non-empty results.
-   Delete an existing document that is part of the results.
-   Verify deleted document results in a REMOVED event.
-   */
+  Attach a listener to a query with non-empty results.
+  Delete an existing document that is part of the results.
+  Verify deleted document results in a REMOVED event.
+  */
   @Test
   public void nonEmptyResults_deletedDocument_REMOVED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -286,10 +286,10 @@ public final class ITQueryWatchTest {
   }
 
   /*
-   Attach a listener to a query with non-empty results.
-   Modify an existing document that is part of the results to no longer match the query.
-   Verify modified document results in a REMOVED event.
-   */
+  Attach a listener to a query with non-empty results.
+  Modify an existing document that is part of the results to no longer match the query.
+  Verify modified document results in a REMOVED event.
+  */
   @Test
   public void nonEmptyResults_modifiedDocument_REMOVED()
       throws InterruptedException, TimeoutException, ExecutionException {
@@ -343,7 +343,8 @@ public final class ITQueryWatchTest {
     private final CountDownLatch cdl;
     private final EnumMap<DocumentChange.Type, CountDownLatch> cdls;
 
-    EventsCountDownLatch(int nonChangeInitial, int addedInitial, int modifiedInitial, int removedInitial) {
+    EventsCountDownLatch(
+        int nonChangeInitial, int addedInitial, int modifiedInitial, int removedInitial) {
       cdl = new CountDownLatch(nonChangeInitial);
       cdls = new EnumMap<>(DocumentChange.Type.class);
       cdls.put(DocumentChange.Type.ADDED, new CountDownLatch(addedInitial));
@@ -464,6 +465,7 @@ public final class ITQueryWatchTest {
       void addedIdsIsAnyOf(Set<?> s) {
         Truth.assertWithMessage(debugMessage()).that(addedIds).isEqualTo(s);
       }
+
       void addedIdsIsAnyOf(Set<?> s1, Set<?> s2) {
         Truth.assertWithMessage(debugMessage()).that(addedIds).isAnyOf(s1, s2);
       }
@@ -524,7 +526,8 @@ public final class ITQueryWatchTest {
         }
       }
 
-      private static void debugMessage(StringBuilder builder, QueryDocumentSnapshot queryDocumentSnapshot) {
+      private static void debugMessage(
+          StringBuilder builder, QueryDocumentSnapshot queryDocumentSnapshot) {
         if (queryDocumentSnapshot == null) {
           builder.append("null");
         } else {

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -62,8 +62,7 @@ public final class ITQueryWatchTest {
 
   private static Firestore firestore;
 
-  @Rule
-  public TestName testName = new TestName();
+  @Rule public TestName testName = new TestName();
 
   private CollectionReference randomColl;
 
@@ -114,8 +113,7 @@ public final class ITQueryWatchTest {
   Start a listener on a query with a non-empty result set
    */
   @Test
-  public void nonEmptyResults()
-      throws InterruptedException, TimeoutException, ExecutionException {
+  public void nonEmptyResults() throws InterruptedException, TimeoutException, ExecutionException {
     // create a document in our collection that will match the query
     randomColl.document("doc").set(map("foo", "bar")).get(5, TimeUnit.SECONDS);
 
@@ -361,8 +359,7 @@ public final class ITQueryWatchTest {
       cdl.await(5, TimeUnit.SECONDS);
     }
 
-    void await(DocumentChange.Type type)
-        throws InterruptedException {
+    void await(DocumentChange.Type type) throws InterruptedException {
       cdls.get(type).await(5, TimeUnit.SECONDS);
     }
   }
@@ -375,10 +372,11 @@ public final class ITQueryWatchTest {
       this(nonChangeInitial, 0, 0, 0);
     }
 
-    QuerySnapshotEventListener(int nonChangeInitial, int addedInitial, int modifiedInitial,
-        int removedInitial) {
+    QuerySnapshotEventListener(
+        int nonChangeInitial, int addedInitial, int modifiedInitial, int removedInitial) {
       this.receivedEvents = Collections.synchronizedList(new ArrayList<ListenerEvent>());
-      this.eventsCDL = new EventsCDL(nonChangeInitial, addedInitial, modifiedInitial, removedInitial);
+      this.eventsCDL =
+          new EventsCDL(nonChangeInitial, addedInitial, modifiedInitial, removedInitial);
     }
 
     @Override
@@ -411,7 +409,6 @@ public final class ITQueryWatchTest {
         addedIds = getIds(querySnapshots, DocumentChange.Type.ADDED);
         modifiedIds = getIds(querySnapshots, DocumentChange.Type.MODIFIED);
         removedIds = getIds(querySnapshots, DocumentChange.Type.REMOVED);
-
       }
 
       private void noError() {
@@ -444,7 +441,9 @@ public final class ITQueryWatchTest {
                 })
             .toList();
       }
-      private static Set<String> getIds(List<QuerySnapshot> querySnapshots, DocumentChange.Type type) {
+
+      private static Set<String> getIds(
+          List<QuerySnapshot> querySnapshots, DocumentChange.Type type) {
         final Set<String> documentIds = new HashSet<>();
         for (QuerySnapshot querySnapshot : querySnapshots) {
           final List<DocumentChange> changes = querySnapshot.getDocumentChanges();

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -152,6 +152,7 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
+      listener.eventsCDL.await();
       randomColl.document("doc").set(map("foo", "bar")).get(5, TimeUnit.SECONDS);
       listener.eventsCDL.await(DocumentChange.Type.ADDED);
     } finally {
@@ -160,7 +161,7 @@ public final class ITQueryWatchTest {
 
     ListenerAssertions la = listener.assertions();
     la.noError();
-    la.eventCountIsAnyOf(Range.closed(1, 2));
+    la.eventCountIsAnyOf(Range.closed(2, 2));
     la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
     la.modifiedIdsIsAnyOf(emptySet());
     la.removedIdsIsAnyOf(emptySet());
@@ -183,6 +184,7 @@ public final class ITQueryWatchTest {
     ListenerRegistration registration = query.addSnapshotListener(listener);
 
     try {
+      listener.eventsCDL.await();
       randomColl.document("doc").update("foo", "bar").get(5, TimeUnit.SECONDS);
       listener.eventsCDL.await(DocumentChange.Type.ADDED);
     } finally {
@@ -191,7 +193,7 @@ public final class ITQueryWatchTest {
 
     ListenerAssertions la = listener.assertions();
     la.noError();
-    la.eventCountIsAnyOf(Range.closed(1, 2));
+    la.eventCountIsAnyOf(Range.closed(2, 2));
     la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
     la.modifiedIdsIsAnyOf(emptySet());
     la.removedIdsIsAnyOf(emptySet());
@@ -231,7 +233,7 @@ public final class ITQueryWatchTest {
 
     ListenerAssertions la = listener.assertions();
     la.noError();
-    la.eventCountIsAnyOf(Range.closed(1, 2));
+    la.eventCountIsAnyOf(Range.closed(2, 2));
     la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
     la.modifiedIdsIsAnyOf(emptySet(), newHashSet("doc"));
     la.removedIdsIsAnyOf(emptySet());
@@ -271,7 +273,7 @@ public final class ITQueryWatchTest {
 
     ListenerAssertions la = listener.assertions();
     la.noError();
-    la.eventCountIsAnyOf(Range.closed(1, 2));
+    la.eventCountIsAnyOf(Range.closed(2, 2));
     la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
     la.modifiedIdsIsAnyOf(emptySet());
     la.removedIdsIsAnyOf(emptySet(), newHashSet("doc"));
@@ -310,7 +312,7 @@ public final class ITQueryWatchTest {
 
     ListenerAssertions la = listener.assertions();
     la.noError();
-    la.eventCountIsAnyOf(Range.closed(1, 2));
+    la.eventCountIsAnyOf(Range.closed(2, 2));
     la.addedIdsIsAnyOf(emptySet(), newHashSet("doc"));
     la.modifiedIdsIsAnyOf(emptySet());
     la.removedIdsIsAnyOf(emptySet(), newHashSet("doc"));

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -17,8 +17,6 @@
 package com.google.cloud.firestore.it;
 
 import static com.google.cloud.firestore.LocalFirestoreHelper.map;
-import static com.google.common.collect.Sets.newHashSet;
-import static com.google.common.truth.Truth.assertWithMessage;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,7 +32,6 @@ import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.CollectionReference;
-import com.google.cloud.firestore.DocumentChange;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.EventListener;
@@ -57,25 +54,17 @@ import com.google.cloud.firestore.Transaction;
 import com.google.cloud.firestore.Transaction.Function;
 import com.google.cloud.firestore.WriteBatch;
 import com.google.cloud.firestore.WriteResult;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.junit.After;
@@ -901,203 +890,6 @@ public class ITSystemTest {
     }
   }
 
-  @Test
-  public void queryWatch() throws Exception {
-    // This test has quite a bit of machinery to it, as there are several things going on.
-    // The main scenario we are test is: 'Given a query, listen for snapshot updates made to that
-    // query'
-    //
-    // To verify this behavior we have the following things happening:
-    //   1. A defined query with an attached snapshot listener.
-    //   2. Two different documents that we are making changes to throughout the duration of the
-    //      test. These changes are expected to trigger a number of events that should be delivered
-    //      to the snapshot listener from 1.
-    //   3. Once all the document updates have been performed, and the expected number of events
-    //      has been delivered to the snapshot listener, the events will be queried for the expected
-    //      series of events and will then be asserted on.
-    //
-    // The mechanics of how the test is executed are as follows
-    //   A. All events delivered to the listener in 1 are added to a list of events we receive.
-    //   B. A separate ExecutorService is created and has tasks submitted to it to perform the
-    //      series of document updates mentioned in 2. (Each document gets its own task).
-    //      * Each of these update tasks will wait for the snapshot listener to be active before
-    //        performing the updates.
-    //   C. CountDownLatches are used to keep track of completion of work while the test is running.
-    //      * Every time an event is received by the listener in 1 a CDL is decremented.
-    //      * Each document update task has a CDL that is decremented when all actions have been
-    //        performed
-    //      * Each CDL has a timeout associated with its await (this is important so that in the
-    //        case there is a hang during the test the whole suite isn't taken with it)
-    //   D. After all updates have been performed and the expected number of events have been
-    //      received, assertions on the events will be performed.
-    //
-    // Note: There is a potential that this test fails if the Firestore backend chooses not to send
-    // us individual changes for every document update, but rather merges two or more changes into
-    // a single event. We have, however, not seen any failures during thousands of test runs.
-    ListenerRegistration registration = null;
-    final ExecutorService updatesExecutor = Executors.newCachedThreadPool();
-
-    final List<ListenerEvent> receivedEvents =
-        Collections.synchronizedList(new ArrayList<ListenerEvent>());
-
-    try {
-      // create our CDLs that are used to track work completion
-      final CountDownLatch doc1CDL = new CountDownLatch(1);
-      final CountDownLatch doc2CDL = new CountDownLatch(1);
-      final CountDownLatch eventsCDL = new CountDownLatch(6);
-
-      // create a CDL that is used to signal the snapshot lister is active.
-      // if we don't do this, there is a possible race with out document updates happening before
-      // the listener has received the "empty" event that is expected in the case that the
-      // result set of the query would be empty (i.e. in the case of an empty collection with new
-      // documents being created)
-      final CountDownLatch snapshotListerActive = new CountDownLatch(1);
-
-      final Query query = randomColl.whereEqualTo("foo", "bar");
-      // register the snapshot listener for the query
-      registration =
-          query.addSnapshotListener(
-              new EventListener<QuerySnapshot>() {
-                @Override
-                public void onEvent(
-                    @Nullable QuerySnapshot value, @Nullable FirestoreException error) {
-                  snapshotListerActive.countDown();
-                  receivedEvents.add(new ListenerEvent(value, error));
-                  eventsCDL.countDown();
-                }
-              });
-
-      // Perform a series of operations on some documents in a separate thread
-      // While we listen for the changes
-      updatesExecutor.submit(
-          new Runnable() {
-            DocumentReference doc1 = randomColl.document("doc1");
-
-            @Override
-            public void run() {
-              try {
-                snapshotListerActive.await(5, TimeUnit.SECONDS);
-                // create the first document
-                doc1.set(map("baz", "foo")).get();
-                // update the document
-                doc1.set(map("foo", "bar")).get();
-                // add a field to the document
-                doc1.set(map("foo", "bar", "bar", "foo")).get();
-                // delete the document
-                doc1.delete().get();
-              } catch (InterruptedException | ExecutionException e) {
-                fail(String.format("Error while processing doc1: %s", e.getMessage()));
-              } finally {
-                doc1CDL.countDown();
-              }
-            }
-          });
-
-      updatesExecutor.submit(
-          new Runnable() {
-            DocumentReference doc2 = randomColl.document("doc2");
-
-            @Override
-            public void run() {
-              try {
-                snapshotListerActive.await(5, TimeUnit.SECONDS);
-                // create a second document
-                doc2.set(map("foo", "bar")).get();
-                // update the document
-                doc2.set(map("foo", "foo")).get();
-              } catch (InterruptedException | ExecutionException e) {
-                fail(String.format("Error while processing doc2: %s", e.getMessage()));
-              } finally {
-                doc2CDL.countDown();
-              }
-            }
-          });
-
-      // Wait for the document update operations to be performed
-      final boolean doc1CDLAwait = doc1CDL.await(10, TimeUnit.SECONDS);
-      assertTrue("all operations for doc1 were not completed in time", doc1CDLAwait);
-      final boolean doc2CDLAwait = doc2CDL.await(10, TimeUnit.SECONDS);
-      assertTrue("all operations for doc2 were not completed in time", doc2CDLAwait);
-
-      // Wait for the expected number of update events to be delivered to our listener
-      eventsCDL.await(30, TimeUnit.SECONDS);
-    } finally {
-      // cleanup out listener
-      if (registration != null) {
-        registration.remove();
-      }
-      // Shutdown the thread pool used to perform the document updates
-      updatesExecutor.shutdown();
-    }
-
-    // Extract certain events from the list of events we received in out listener
-
-    final FluentIterable<ListenerEvent> events = FluentIterable.from(receivedEvents);
-
-    final Optional<ListenerEvent> anyError =
-        events.firstMatch(
-            new Predicate<ListenerEvent>() {
-              @Override
-              public boolean apply(ListenerEvent input) {
-                return input.error != null;
-              }
-            });
-    assertWithMessage("snapshotListener received an error").that(anyError).isAbsent();
-
-    final FluentIterable<QuerySnapshot> querySnapshots =
-        events
-            .filter(
-                new Predicate<ListenerEvent>() {
-                  @Override
-                  public boolean apply(ListenerEvent input) {
-                    return input.value != null;
-                  }
-                })
-            .transform(
-                new com.google.common.base.Function<ListenerEvent, QuerySnapshot>() {
-                  @Override
-                  public QuerySnapshot apply(ListenerEvent input) {
-                    return input.value;
-                  }
-                });
-
-    final Optional<QuerySnapshot> initialEmpty =
-        querySnapshots.firstMatch(
-            new Predicate<QuerySnapshot>() {
-              @Override
-              public boolean apply(QuerySnapshot input) {
-                return input.isEmpty() && input.getDocumentChanges().size() == 0;
-              }
-            });
-    final Set<String> addedDocumentIds = getIds(querySnapshots, DocumentChange.Type.ADDED);
-    final Set<String> modifiedDocumentIds = getIds(querySnapshots, DocumentChange.Type.MODIFIED);
-    final Set<String> removedDocumentIds = getIds(querySnapshots, DocumentChange.Type.REMOVED);
-    final Optional<QuerySnapshot> finalRemove =
-        querySnapshots.firstMatch(
-            new Predicate<QuerySnapshot>() {
-              @Override
-              public boolean apply(QuerySnapshot input) {
-                return input.isEmpty() && input.getDocumentChanges().size() == 1;
-              }
-            });
-
-    assertWithMessage("snapshotListener did not receive expected initial empty event")
-        .that(initialEmpty)
-        .isPresent();
-    assertWithMessage("snapshotListener did not receive expected added events")
-        .that(addedDocumentIds)
-        .isEqualTo(newHashSet("doc1", "doc2"));
-    assertWithMessage("snapshotListener did not receive expected modified events")
-        .that(modifiedDocumentIds)
-        .isEqualTo(newHashSet("doc1"));
-    assertWithMessage("snapshotListener did not receive expected removed events")
-        .that(removedDocumentIds)
-        .isEqualTo(newHashSet("doc1", "doc2"));
-    assertWithMessage("snapshotListener did not receive expected final empty event")
-        .that(finalRemove)
-        .isPresent();
-  }
-
   private int paginateResults(Query query, List<DocumentSnapshot> results)
       throws ExecutionException, InterruptedException {
     if (!results.isEmpty()) {
@@ -1338,35 +1130,6 @@ public class ITSystemTest {
     docRef.update("sum", FieldValue.increment(2.2)).get();
     DocumentSnapshot docSnap = docRef.get().get();
     assertEquals(3.3, (Double) docSnap.get("sum"), DOUBLE_EPSILON);
-  }
-
-  private static Set<String> getIds(
-      FluentIterable<QuerySnapshot> querySnapshots, DocumentChange.Type type) {
-    final Set<String> documentIds = new HashSet<>();
-    for (QuerySnapshot querySnapshot : querySnapshots) {
-      final List<DocumentChange> changes = querySnapshot.getDocumentChanges();
-      for (DocumentChange change : changes) {
-        if (change.getType() == type) {
-          documentIds.add(change.getDocument().getId());
-        }
-      }
-    }
-    return documentIds;
-  }
-
-  /**
-   * A tuple class used by {@code #queryWatch}. This class represents an event delivered to the
-   * registered query listener.
-   */
-  private static final class ListenerEvent {
-
-    @Nullable private final QuerySnapshot value;
-    @Nullable private final FirestoreException error;
-
-    ListenerEvent(@Nullable QuerySnapshot value, @Nullable FirestoreException error) {
-      this.value = value;
-      this.error = error;
-    }
   }
 
   @Test


### PR DESCRIPTION
queryWatch has been flaky because several things are happening in the
single event stream. This fix splits up the different scenarios being
tested into their own respective tests and updates the assertions to be
more specific to the scenario as well as handling the semantics of the
backend better.
