### PR TITLE
fix: add cause to transaction errors on transaction commit

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreException.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreException.java
@@ -28,7 +28,11 @@ public final class FirestoreException extends BaseGrpcServiceException {
   private Status status;
 
   private FirestoreException(String reason, Status status) {
-    super(reason, null, status.getCode().value(), false);
+    this(reason, status, null);
+  }
+
+  private FirestoreException(String reason, Status status, @Nullable Throwable cause) {
+    super(reason, cause, status.getCode().value(), false);
 
     this.status = status;
   }
@@ -58,7 +62,17 @@ public final class FirestoreException extends BaseGrpcServiceException {
    * @return The FirestoreException
    */
   static FirestoreException serverRejected(Status status, String message, Object... params) {
-    return new FirestoreException(String.format(message, params), status);
+      return serverRejected(status, null, message, params);
+  }
+
+  /**
+   * Creates a FirestoreException with the provided GRPC Status code and message in a nested
+   * exception.
+   *
+   * @return The FirestoreException
+   */
+  static FirestoreException serverRejected(Status status, @Nullable Throwable cause, String message, Object... params) {
+    return new FirestoreException(String.format(message, params), status, cause);
   }
 
   /**

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreException.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreException.java
@@ -62,7 +62,7 @@ public final class FirestoreException extends BaseGrpcServiceException {
    * @return The FirestoreException
    */
   static FirestoreException serverRejected(Status status, String message, Object... params) {
-      return serverRejected(status, null, message, params);
+    return serverRejected(status, null, message, params);
   }
 
   /**
@@ -71,7 +71,8 @@ public final class FirestoreException extends BaseGrpcServiceException {
    *
    * @return The FirestoreException
    */
-  static FirestoreException serverRejected(Status status, @Nullable Throwable cause, String message, Object... params) {
+  static FirestoreException serverRejected(
+      Status status, @Nullable Throwable cause, String message, Object... params) {
     return new FirestoreException(String.format(message, params), status, cause);
   }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -406,7 +406,9 @@ class FirestoreImpl implements Firestore {
               span.setStatus(TOO_MANY_RETRIES_STATUS);
               rejectTransaction(
                   FirestoreException.serverRejected(
-                      Status.ABORTED, throwable, "Transaction was cancelled because of too many retries."));
+                      Status.ABORTED,
+                      throwable,
+                      "Transaction was cancelled because of too many retries."));
             }
           }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -360,7 +360,7 @@ class FirestoreImpl implements Firestore {
                           @Override
                           public void onFailure(Throwable throwable) {
                             // Retry failed commits.
-                            maybeRetry();
+                            maybeRetry(throwable);
                           }
 
                           @Override
@@ -393,7 +393,7 @@ class FirestoreImpl implements Firestore {
             return callbackResult;
           }
 
-          private void maybeRetry() {
+          private void maybeRetry(Throwable throwable) {
             if (attemptsRemaining > 0) {
               span.addAnnotation("retrying");
               runTransactionAttempt(
@@ -406,7 +406,7 @@ class FirestoreImpl implements Firestore {
               span.setStatus(TOO_MANY_RETRIES_STATUS);
               rejectTransaction(
                   FirestoreException.serverRejected(
-                      Status.ABORTED, "Transaction was cancelled because of too many retries."));
+                      Status.ABORTED, throwable, "Transaction was cancelled because of too many retries."));
             }
           }
 


### PR DESCRIPTION
Right now if a transaction fails due to a precondition failure (which are retried, which is another bug) for example trying to update a document that doesn't exist you get a bad error message of "too many retries". Ideally retry is smarter, but this is a easy change that propagates the underlying error up to the ApiFuture result.

/cc @schmidt-sebastian @BenWhitehead 