### PR TITLE
chore: use java helper for templates

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -117,10 +117,7 @@ firestore_v1beta1 = generate_client(
     include_gapic=False
 )
 
-common_templates = gcp.CommonTemplates()
-templates = common_templates.java_library()
-s.copy(templates, excludes=[
-    '.gitignore',
+java.common_templates(excludes=[
     'README.md',
     # firestore uses a different project for its integration tests
     # due to the default project running datastore


### PR DESCRIPTION
We are cleaning up usage of common templates in synthtool. This allows us the cleanup usage in a centralized place rather than in 60+ repos