### PR TITLE
fix: add missing @InternalExtensionOnly annotation to com.google.cloud.firestore.Firestore

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Firestore.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Firestore.java
@@ -17,6 +17,7 @@
 package com.google.cloud.firestore;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.cloud.Service;
 import java.util.List;
@@ -24,6 +25,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Represents a Firestore Database and is the entry point for all Firestore operations */
+@InternalExtensionOnly
 public interface Firestore extends Service<FirestoreOptions>, AutoCloseable {
 
   /**


### PR DESCRIPTION
"Client" interfaces make guarantees around compatibility for users
direct usage, however no guarantee is made for anyone implementing
the "client" interface themselves. This change adds the annotation
intended to convey this guarantee at the code level and in javadocs
that should have been here all along.
