### PR TITLE
docs: update README to include code formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,15 @@ mvn -Penable-samples clean verify
 2. [Activate](#profile-activation) the profile.
 3. Define your samples in a normal Maven project in the `samples/` directory
 
+### Code Formatting
+
+Code in this repo is formatted with [google-java-format]
+(https://github.com/google/google-java-format).
+To run formatting on your project, you can run:
+```
+mvn com.coveo:fmt-maven-plugin:format
+```
+
 ### Profile Activation
 
 To include code samples when building and testing the project, enable the 


### PR DESCRIPTION
In a game of telephone, Sebastian told me that you told him this was a command you can run to lint the java-firestore repo. Adding to `CONTRIBUTING.md` for future contributors.