### PR TITLE
fix: replace usages of transform proto with update_transform

### DIFF
--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -162,7 +162,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-conformance-tests</artifactId>
-      <version>0.0.10</version>
+      <version>0.0.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -162,7 +162,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-conformance-tests</artifactId>
-      <version>0.0.11-SNAPSHOT</version>
+      <version>0.0.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -162,7 +162,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-conformance-tests</artifactId>
-      <version>0.0.10</version>
+      <version>0.0.11-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentTransform.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentTransform.java
@@ -17,7 +17,7 @@
 package com.google.cloud.firestore;
 
 import com.google.firestore.v1.DocumentTransform.FieldTransform;
-import com.google.firestore.v1.Write;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -30,12 +30,9 @@ import java.util.TreeMap;
  */
 final class DocumentTransform {
 
-  private DocumentReference documentReference;
   private final SortedMap<FieldPath, FieldTransform> transforms; // Sorted for testing.
 
-  private DocumentTransform(
-      DocumentReference documentReference, SortedMap<FieldPath, FieldTransform> transforms) {
-    this.documentReference = documentReference;
+  private DocumentTransform(SortedMap<FieldPath, FieldTransform> transforms) {
     this.transforms = transforms;
   }
 
@@ -61,7 +58,7 @@ final class DocumentTransform {
       }
     }
 
-    return new DocumentTransform(documentReference, transforms);
+    return new DocumentTransform(transforms);
   }
 
   private static SortedMap<FieldPath, FieldTransform> extractFromMap(
@@ -116,11 +113,7 @@ final class DocumentTransform {
     return Collections.unmodifiableSet(transforms.keySet());
   }
 
-  Write.Builder toPb() {
-    Write.Builder write = Write.newBuilder();
-    com.google.firestore.v1.DocumentTransform.Builder transform = write.getTransformBuilder();
-    transform.addAllFieldTransforms(transforms.values());
-    transform.setDocument(documentReference.getName());
-    return write;
+  Collection<FieldTransform> toPb() {
+    return transforms.values();
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -129,7 +129,6 @@ public abstract class UpdateBuilder<T extends UpdateBuilder> {
     return (T) this;
   }
 
-  /** Adds a new write to the batch. */
   private void verifyNotCommitted() {
     Preconditions.checkState(
         !committed, "Cannot modify a WriteBatch that has already been committed.");

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -623,7 +623,7 @@ public abstract class UpdateBuilder<T extends UpdateBuilder> {
   }
 
   /** Get the number of writes. */
-  public int getNumWrites() {
+  public int getMutationsSize() {
     return writes.size();
   }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/DocumentReferenceTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/DocumentReferenceTest.java
@@ -53,7 +53,6 @@ import static com.google.cloud.firestore.LocalFirestoreHelper.streamingResponse;
 import static com.google.cloud.firestore.LocalFirestoreHelper.string;
 import static com.google.cloud.firestore.LocalFirestoreHelper.transform;
 import static com.google.cloud.firestore.LocalFirestoreHelper.update;
-import static com.google.cloud.firestore.LocalFirestoreHelper.writeWithTransform;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -405,9 +404,8 @@ public class DocumentReferenceTest {
 
     CommitRequest create =
         commit(
-            writeWithTransform(
-                create(Collections.<String, Value>emptyMap()),
-                transform("foo", serverTimestamp(), "inner.bar", serverTimestamp())));
+            create(Collections.<String, Value>emptyMap()),
+            transform("foo", serverTimestamp(), "inner.bar", serverTimestamp()));
 
     List<CommitRequest> commitRequests = commitCapture.getAllValues();
     assertCommitEquals(create, commitRequests.get(0));
@@ -426,9 +424,8 @@ public class DocumentReferenceTest {
 
     CommitRequest set =
         commit(
-            writeWithTransform(
-                set(SERVER_TIMESTAMP_PROTO),
-                transform("foo", serverTimestamp(), "inner.bar", serverTimestamp())));
+            set(SERVER_TIMESTAMP_PROTO),
+            transform("foo", serverTimestamp(), "inner.bar", serverTimestamp()));
 
     List<CommitRequest> commitRequests = commitCapture.getAllValues();
     assertCommitEquals(set, commitRequests.get(0));
@@ -446,9 +443,8 @@ public class DocumentReferenceTest {
 
     CommitRequest update =
         commit(
-            writeWithTransform(
-                update(Collections.<String, Value>emptyMap(), Collections.singletonList("inner")),
-                transform("foo", serverTimestamp(), "inner.bar", serverTimestamp())));
+            update(Collections.<String, Value>emptyMap(), Collections.singletonList("inner")),
+            transform("foo", serverTimestamp(), "inner.bar", serverTimestamp()));
 
     assertCommitEquals(update, commitCapture.getValue());
 
@@ -457,12 +453,11 @@ public class DocumentReferenceTest {
 
     update =
         commit(
-            writeWithTransform(
-                update(
-                    Collections.<String, Value>emptyMap(),
-                    new ArrayList<String>(),
-                    UPDATE_PRECONDITION),
-                transform("foo", serverTimestamp(), "inner.bar", serverTimestamp())));
+            update(
+                Collections.<String, Value>emptyMap(),
+                new ArrayList<String>(),
+                UPDATE_PRECONDITION),
+            transform("foo", serverTimestamp(), "inner.bar", serverTimestamp()));
 
     assertCommitEquals(update, commitCapture.getValue());
   }
@@ -483,9 +478,8 @@ public class DocumentReferenceTest {
 
     CommitRequest set =
         commit(
-            writeWithTransform(
-                set(SERVER_TIMESTAMP_PROTO, new ArrayList<String>()),
-                transform("inner.bar", serverTimestamp())));
+            set(SERVER_TIMESTAMP_PROTO, new ArrayList<String>()),
+            transform("inner.bar", serverTimestamp()));
 
     List<CommitRequest> commitRequests = commitCapture.getAllValues();
     assertCommitEquals(set, commitRequests.get(0));
@@ -505,13 +499,12 @@ public class DocumentReferenceTest {
 
     CommitRequest set =
         commit(
-            writeWithTransform(
-                set(Collections.<String, Value>emptyMap()),
-                transform(
-                    "integer",
-                    increment(Value.newBuilder().setIntegerValue(1).build()),
-                    "double",
-                    increment(Value.newBuilder().setDoubleValue(1.1).build()))));
+            set(Collections.<String, Value>emptyMap()),
+            transform(
+                "integer",
+                increment(Value.newBuilder().setIntegerValue(1).build()),
+                "double",
+                increment(Value.newBuilder().setDoubleValue(1.1).build())));
 
     CommitRequest commitRequest = commitCapture.getValue();
     assertCommitEquals(set, commitRequest);
@@ -528,9 +521,8 @@ public class DocumentReferenceTest {
 
     CommitRequest set =
         commit(
-            writeWithTransform(
-                set(Collections.<String, Value>emptyMap()),
-                transform("foo", arrayUnion(string("bar"), object("foo", string("baz"))))));
+            set(Collections.<String, Value>emptyMap()),
+            transform("foo", arrayUnion(string("bar"), object("foo", string("baz")))));
 
     CommitRequest commitRequest = commitCapture.getValue();
     assertCommitEquals(set, commitRequest);
@@ -547,9 +539,8 @@ public class DocumentReferenceTest {
 
     CommitRequest set =
         commit(
-            writeWithTransform(
-                set(Collections.<String, Value>emptyMap()),
-                transform("foo", arrayRemove(string("bar"), object("foo", string("baz"))))));
+            set(Collections.<String, Value>emptyMap()),
+            transform("foo", arrayRemove(string("bar"), object("foo", string("baz")))));
 
     CommitRequest commitRequest = commitCapture.getValue();
     assertCommitEquals(set, commitRequest);

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/FirestoreTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/FirestoreTest.java
@@ -26,7 +26,6 @@ import static com.google.cloud.firestore.LocalFirestoreHelper.commitResponse;
 import static com.google.cloud.firestore.LocalFirestoreHelper.getAllResponse;
 import static com.google.cloud.firestore.LocalFirestoreHelper.transform;
 import static com.google.cloud.firestore.LocalFirestoreHelper.update;
-import static com.google.cloud.firestore.LocalFirestoreHelper.writeWithTransform;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -201,9 +200,8 @@ public class FirestoreTest {
 
     CommitRequest expectedRequest =
         commit(
-            writeWithTransform(
-                update(Collections.<String, Value>emptyMap(), new ArrayList<String>()),
-                transform("array", arrayUnion(SINGLE_FIELD_VALUE))));
+            update(Collections.<String, Value>emptyMap(), new ArrayList<String>()),
+            transform("array", arrayUnion(SINGLE_FIELD_VALUE)));
     CommitRequest actualRequest = commitCapture.getValue();
     assertEquals(expectedRequest, actualRequest);
   }
@@ -220,9 +218,8 @@ public class FirestoreTest {
 
     CommitRequest expectedRequest =
         commit(
-            writeWithTransform(
-                update(Collections.<String, Value>emptyMap(), new ArrayList<String>()),
-                transform("array", arrayRemove(SINGLE_FIELD_VALUE))));
+            update(Collections.<String, Value>emptyMap(), new ArrayList<String>()),
+            transform("array", arrayRemove(SINGLE_FIELD_VALUE)));
     CommitRequest actualRequest = commitCapture.getValue();
     assertEquals(expectedRequest, actualRequest);
   }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/FirestoreTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/FirestoreTest.java
@@ -19,13 +19,14 @@ package com.google.cloud.firestore;
 import static com.google.cloud.firestore.LocalFirestoreHelper.SINGLE_FIELD_OBJECT;
 import static com.google.cloud.firestore.LocalFirestoreHelper.SINGLE_FIELD_PROTO;
 import static com.google.cloud.firestore.LocalFirestoreHelper.SINGLE_FIELD_VALUE;
-import static com.google.cloud.firestore.LocalFirestoreHelper.UPDATE_PRECONDITION;
 import static com.google.cloud.firestore.LocalFirestoreHelper.arrayRemove;
 import static com.google.cloud.firestore.LocalFirestoreHelper.arrayUnion;
 import static com.google.cloud.firestore.LocalFirestoreHelper.commit;
 import static com.google.cloud.firestore.LocalFirestoreHelper.commitResponse;
 import static com.google.cloud.firestore.LocalFirestoreHelper.getAllResponse;
 import static com.google.cloud.firestore.LocalFirestoreHelper.transform;
+import static com.google.cloud.firestore.LocalFirestoreHelper.update;
+import static com.google.cloud.firestore.LocalFirestoreHelper.writeWithTransform;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -40,6 +41,9 @@ import com.google.firestore.v1.BatchGetDocumentsRequest;
 import com.google.firestore.v1.CommitRequest;
 import com.google.firestore.v1.CommitResponse;
 import com.google.firestore.v1.ListCollectionIdsRequest;
+import com.google.firestore.v1.Value;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
@@ -196,7 +200,10 @@ public class FirestoreTest {
     doc.update("array", FieldValue.arrayUnion(SINGLE_FIELD_OBJECT)).get();
 
     CommitRequest expectedRequest =
-        commit(transform(UPDATE_PRECONDITION, "array", arrayUnion(SINGLE_FIELD_VALUE)));
+        commit(
+            writeWithTransform(
+                update(Collections.<String, Value>emptyMap(), new ArrayList<String>()),
+                transform("array", arrayUnion(SINGLE_FIELD_VALUE))));
     CommitRequest actualRequest = commitCapture.getValue();
     assertEquals(expectedRequest, actualRequest);
   }
@@ -212,7 +219,10 @@ public class FirestoreTest {
     doc.update("array", FieldValue.arrayRemove(SINGLE_FIELD_OBJECT)).get();
 
     CommitRequest expectedRequest =
-        commit(transform(UPDATE_PRECONDITION, "array", arrayRemove(SINGLE_FIELD_VALUE)));
+        commit(
+            writeWithTransform(
+                update(Collections.<String, Value>emptyMap(), new ArrayList<String>()),
+                transform("array", arrayRemove(SINGLE_FIELD_VALUE))));
     CommitRequest actualRequest = commitCapture.getValue();
     assertEquals(expectedRequest, actualRequest);
   }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
@@ -440,8 +440,8 @@ public final class LocalFirestoreHelper {
     return commit(null, writes);
   }
 
-  public static Write writeWithTransform(Write write, List<FieldTransform> transforms) {
-    return write.toBuilder().addAllUpdateTransforms(transforms).build();
+  public static CommitRequest commit(Write write, List<FieldTransform> transforms) {
+    return commit((String) null, write.toBuilder().addAllUpdateTransforms(transforms).build());
   }
 
   public static StructuredQuery filter(StructuredQuery.FieldFilter.Operator operator) {

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WriteBatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WriteBatchTest.java
@@ -215,7 +215,7 @@ public class WriteBatchTest {
 
   @Test
   public void omitWriteResultForDocumentTransforms() throws Exception {
-    doReturn(commitResponse(2, 0))
+    doReturn(commitResponse(1, 0))
         .when(firestoreMock)
         .sendRequest(
             commitCapture.capture(), Matchers.<UnaryCallable<CommitRequest, CommitResponse>>any());

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WriteBatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WriteBatchTest.java
@@ -93,7 +93,7 @@ public class WriteBatchTest {
     batch.update(documentReference, updateTime, "foo", "bar");
     batch.update(documentReference, LocalFirestoreHelper.SINGLE_FIELD_MAP, updateTime);
 
-    assertEquals(4, batch.getNumWrites());
+    assertEquals(4, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     List<Write> writes = new ArrayList<>();
@@ -119,7 +119,7 @@ public class WriteBatchTest {
             commitCapture.capture(), Matchers.<UnaryCallable<CommitRequest, CommitResponse>>any());
 
     batch.update(documentReference, "foo", UPDATE_SINGLE_FIELD_OBJECT);
-    assertEquals(1, batch.getNumWrites());
+    assertEquals(1, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     assertEquals(1, writeResults.size());
@@ -149,7 +149,7 @@ public class WriteBatchTest {
     writes.add(set(LocalFirestoreHelper.SINGLE_FIELD_PROTO, Arrays.asList("foo")));
     writes.add(set(LocalFirestoreHelper.SINGLE_FIELD_PROTO, Arrays.asList("foo")));
 
-    assertEquals(4, batch.getNumWrites());
+    assertEquals(4, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     for (int i = 0; i < writeResults.size(); ++i) {
@@ -179,7 +179,7 @@ public class WriteBatchTest {
     writes.add(set(LocalFirestoreHelper.SINGLE_FIELD_PROTO, Arrays.asList("foo")));
     writes.add(set(LocalFirestoreHelper.SINGLE_FIELD_PROTO, Arrays.asList("foo")));
 
-    assertEquals(4, batch.getNumWrites());
+    assertEquals(4, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     for (int i = 0; i < writeResults.size(); ++i) {
@@ -202,7 +202,7 @@ public class WriteBatchTest {
     List<Write> writes = new ArrayList<>();
     writes.add(set(LocalFirestoreHelper.SINGLE_FLOAT_PROTO));
 
-    assertEquals(1, batch.getNumWrites());
+    assertEquals(1, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     for (int i = 0; i < writeResults.size(); ++i) {
@@ -222,7 +222,7 @@ public class WriteBatchTest {
 
     batch.set(documentReference, map("time", FieldValue.serverTimestamp()));
 
-    assertEquals(1, batch.getNumWrites());
+    assertEquals(1, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     assertEquals(1, writeResults.size());
@@ -239,7 +239,7 @@ public class WriteBatchTest {
         .create(documentReference, LocalFirestoreHelper.SINGLE_FIELD_MAP)
         .create(documentReference, LocalFirestoreHelper.SINGLE_FIELD_OBJECT);
 
-    assertEquals(2, batch.getNumWrites());
+    assertEquals(2, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     List<Write> writes = new ArrayList<>();
@@ -264,7 +264,7 @@ public class WriteBatchTest {
         .create(documentReference, LocalFirestoreHelper.SINGLE_FIELD_PROTO)
         .create(documentReference, LocalFirestoreHelper.SINGLE_FIELD_OBJECT);
 
-    assertEquals(2, batch.getNumWrites());
+    assertEquals(2, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     List<Write> writes = new ArrayList<>();
@@ -287,7 +287,7 @@ public class WriteBatchTest {
 
     batch.create(documentReference, LocalFirestoreHelper.SINGLE_FLOAT_MAP);
 
-    assertEquals(1, batch.getNumWrites());
+    assertEquals(1, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
     List<Write> writes = new ArrayList<>();
@@ -318,7 +318,7 @@ public class WriteBatchTest {
     precondition.getUpdateTimeBuilder().setSeconds(1).setNanos(2);
     writes.add(delete(precondition.build()));
 
-    assertEquals(2, batch.getNumWrites());
+    assertEquals(2, batch.getMutationsSize());
 
     List<WriteResult> writeResults = batch.commit().get();
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WriteBatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WriteBatchTest.java
@@ -93,7 +93,7 @@ public class WriteBatchTest {
     batch.update(documentReference, updateTime, "foo", "bar");
     batch.update(documentReference, LocalFirestoreHelper.SINGLE_FIELD_MAP, updateTime);
 
-    assertEquals(4, batch.getMutationsSize());
+    assertEquals(4, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     List<Write> writes = new ArrayList<>();
@@ -119,7 +119,7 @@ public class WriteBatchTest {
             commitCapture.capture(), Matchers.<UnaryCallable<CommitRequest, CommitResponse>>any());
 
     batch.update(documentReference, "foo", UPDATE_SINGLE_FIELD_OBJECT);
-    assertEquals(1, batch.getMutationsSize());
+    assertEquals(1, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     assertEquals(1, writeResults.size());
@@ -149,7 +149,7 @@ public class WriteBatchTest {
     writes.add(set(LocalFirestoreHelper.SINGLE_FIELD_PROTO, Arrays.asList("foo")));
     writes.add(set(LocalFirestoreHelper.SINGLE_FIELD_PROTO, Arrays.asList("foo")));
 
-    assertEquals(4, batch.getMutationsSize());
+    assertEquals(4, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     for (int i = 0; i < writeResults.size(); ++i) {
@@ -179,7 +179,7 @@ public class WriteBatchTest {
     writes.add(set(LocalFirestoreHelper.SINGLE_FIELD_PROTO, Arrays.asList("foo")));
     writes.add(set(LocalFirestoreHelper.SINGLE_FIELD_PROTO, Arrays.asList("foo")));
 
-    assertEquals(4, batch.getMutationsSize());
+    assertEquals(4, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     for (int i = 0; i < writeResults.size(); ++i) {
@@ -202,7 +202,7 @@ public class WriteBatchTest {
     List<Write> writes = new ArrayList<>();
     writes.add(set(LocalFirestoreHelper.SINGLE_FLOAT_PROTO));
 
-    assertEquals(1, batch.getMutationsSize());
+    assertEquals(1, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     for (int i = 0; i < writeResults.size(); ++i) {
@@ -222,7 +222,7 @@ public class WriteBatchTest {
 
     batch.set(documentReference, map("time", FieldValue.serverTimestamp()));
 
-    assertEquals(1, batch.getMutationsSize());
+    assertEquals(1, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     assertEquals(1, writeResults.size());
@@ -239,7 +239,7 @@ public class WriteBatchTest {
         .create(documentReference, LocalFirestoreHelper.SINGLE_FIELD_MAP)
         .create(documentReference, LocalFirestoreHelper.SINGLE_FIELD_OBJECT);
 
-    assertEquals(2, batch.getMutationsSize());
+    assertEquals(2, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     List<Write> writes = new ArrayList<>();
@@ -264,7 +264,7 @@ public class WriteBatchTest {
         .create(documentReference, LocalFirestoreHelper.SINGLE_FIELD_PROTO)
         .create(documentReference, LocalFirestoreHelper.SINGLE_FIELD_OBJECT);
 
-    assertEquals(2, batch.getMutationsSize());
+    assertEquals(2, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     List<Write> writes = new ArrayList<>();
@@ -287,7 +287,7 @@ public class WriteBatchTest {
 
     batch.create(documentReference, LocalFirestoreHelper.SINGLE_FLOAT_MAP);
 
-    assertEquals(1, batch.getMutationsSize());
+    assertEquals(1, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
     List<Write> writes = new ArrayList<>();
@@ -318,7 +318,7 @@ public class WriteBatchTest {
     precondition.getUpdateTimeBuilder().setSeconds(1).setNanos(2);
     writes.add(delete(precondition.build()));
 
-    assertEquals(2, batch.getMutationsSize());
+    assertEquals(2, batch.getNumWrites());
 
     List<WriteResult> writeResults = batch.commit().get();
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -228,6 +228,15 @@ public class ITSystemTest {
   }
 
   @Test
+  public void setWithIncrementAndMerge() throws ExecutionException, InterruptedException {
+    DocumentReference docRef = randomColl.document();
+    docRef.set(Collections.singletonMap("sum", 1L)).get();
+    docRef.set(Collections.singletonMap("sum", FieldValue.increment(2)), SetOptions.merge()).get();
+    DocumentSnapshot docSnap = docRef.get().get();
+    assertEquals(3L, docSnap.get("sum"));
+  }
+
+  @Test
   public void mergeDocumentWithServerTimestamp() throws Exception {
     Map<String, Object> originalMap = LocalFirestoreHelper.<String, Object>map("a", "b");
     Map<String, FieldValue> updateMap = map("c", FieldValue.serverTimestamp());


### PR DESCRIPTION
Porting from [node](https://github.com/googleapis/nodejs-firestore/pull/949). Also added additional system test [port](https://github.com/googleapis/nodejs-firestore/pull/1035/files#diff-6b8febc8d51ea01205628091b3611eacR422) as well. 

Conformance tests are passing locally against the custom [branch] of modified conformance tests (https://github.com/googleapis/java-conformance-tests/tree/bump/2020-05-12_141750) in `googleapis/java-conformance-test`. According to @BenWhitehead, once this PR is LGTM'd, we will:
1. Merge the conformance test [PR](https://github.com/googleapis/conformance-tests/pull/34) into `conformance-tests`.
2. Create new release of `java-conformance-tests`. 
3. Update `java-firestore` to the new release.
4. Rebuild this PR and ensure everything passes before merging. 