### PR TITLE
fix: catch null Firestore in system tests

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryWatchTest.java
@@ -39,6 +39,7 @@ import com.google.cloud.firestore.it.ITQueryWatchTest.QuerySnapshotEventListener
 import com.google.common.base.Joiner;
 import com.google.common.base.Joiner.MapJoiner;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Range;
@@ -83,6 +84,9 @@ public final class ITQueryWatchTest {
 
   @AfterClass
   public static void afterClass() throws Exception {
+    Preconditions.checkNotNull(
+        firestore,
+        "Error instantiating Firestore. Check that the service account credentials were properly set.");
     firestore.close();
   }
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -55,6 +55,7 @@ import com.google.cloud.firestore.Transaction;
 import com.google.cloud.firestore.Transaction.Function;
 import com.google.cloud.firestore.WriteBatch;
 import com.google.cloud.firestore.WriteResult;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
@@ -104,6 +105,9 @@ public class ITSystemTest {
 
   @After
   public void after() throws Exception {
+    Preconditions.checkNotNull(
+        firestore,
+        "Error instantiating Firestore. Check that the service account credentials were properly set.");
     firestore.close();
   }
 


### PR DESCRIPTION
Checking for null in the `before()` block doesn't surface the error, since the `after()` call will still run even with a thrown exception, smothering the error.