### PR TITLE
fix: Fields used in whereIn should be equality filters

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
@@ -149,7 +149,14 @@ public class Query {
 
     @Override
     boolean isEqualsFilter() {
-      return operator.equals(EQUAL);
+      return !isInequalityFilter();
+    }
+
+    private boolean isInequalityFilter() {
+      return operator.equals(GREATER_THAN)
+          || operator.equals(GREATER_THAN_OR_EQUAL)
+          || operator.equals(LESS_THAN)
+          || operator.equals(LESS_THAN_OR_EQUAL);
     }
 
     Filter toProto() {

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
@@ -104,7 +104,7 @@ public class Query {
       return encodedValue;
     }
 
-    abstract boolean isEqualsFilter();
+    abstract boolean isInequalityFilter();
 
     abstract Filter toProto();
   }
@@ -117,8 +117,8 @@ public class Query {
     }
 
     @Override
-    boolean isEqualsFilter() {
-      return true;
+    boolean isInequalityFilter() {
+      return false;
     }
 
     Filter toProto() {
@@ -148,11 +148,7 @@ public class Query {
     }
 
     @Override
-    boolean isEqualsFilter() {
-      return !isInequalityFilter();
-    }
-
-    private boolean isInequalityFilter() {
+    boolean isInequalityFilter() {
       return operator.equals(GREATER_THAN)
           || operator.equals(GREATER_THAN_OR_EQUAL)
           || operator.equals(LESS_THAN)
@@ -313,7 +309,7 @@ public class Query {
     if (implicitOrders.isEmpty()) {
       // If no explicit ordering is specified, use the first inequality to define an implicit order.
       for (FieldFilter fieldFilter : options.getFieldFilters()) {
-        if (!fieldFilter.isEqualsFilter()) {
+        if (fieldFilter.isInequalityFilter()) {
           implicitOrders.add(new FieldOrder(fieldFilter.fieldPath, Direction.ASCENDING));
           break;
         }


### PR DESCRIPTION
Fields appear in `whereIn` queries are used as implicit orderBys. This is wrong because `In` should be an equality filter.

This change brings Java SDK in line with Node in terms of how equality/inequality filters are determined.