### PR TITLE
chore: update CODEOWNERS, CONTRIBUTING from templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,11 @@
 # Code owners file.
 # This file controls who is tagged for review for any given pull request.
-#
+
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
+# The @googleapis/firestore-dpe is the default owner for changes in this repo
+**/*.java               @googleapis/firestore-dpe
 
-# The firestore-dpe team is the default owner for anything not
-# explicitly taken by someone else.
-*                               @googleapis/firestore-dpe
+# The java-samples-reviewers team is the default owner for samples changes
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,6 @@
   "repo": "googleapis/java-firestore",
   "repo_short": "java-firestore",
   "distribution_name": "com.google.cloud:google-cloud-firestore",
+  "codeowner_team": "@googleapis/firestore-dpe",
   "api_id": "firestore.googleapis.com"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,12 +99,12 @@ mvn -Penable-samples clean verify
     ```
 
 2. [Activate](#profile-activation) the profile.
-3. Define your samples in a normal Maven project in the `samples/` directory
+3. Define your samples in a normal Maven project in the `samples/` directory.
 
 ### Code Formatting
 
-Code in this repo is formatted with [google-java-format]
-(https://github.com/google/google-java-format).
+Code in this repo is formatted with
+[google-java-format](https://github.com/google/google-java-format).
 To run formatting on your project, you can run:
 ```
 mvn com.coveo:fmt-maven-plugin:format

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,23 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/java-firestore.git",
-        "sha": "495f7f97405fcd2bff4d09e67ddbeb51615ea843"
+        "remote": "git@github.com:googleapis/java-firestore.git",
+        "sha": "dbb17be9bacd4876d5249678401f5fb38460b2af"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "d4aa417ed2bba89c2d216900282bddfdafef6128",
-        "internalRef": "303010132"
+        "sha": "c1fae183ddeef0c59538863eac611fd679d1b7fb",
+        "internalRef": "314634470"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "52638600f387deb98efb5f9c85fec39e82aa9052"
+        "sha": "8b65daa222d193b689279162781baf0aa1f0ffd2"
       }
     }
   ],


### PR DESCRIPTION
CODEOWNERS is now managed by templates and we can configure the default team in the .repo-metadata.json file.