### PR TITLE
feat: add API to serialize Queries to Proto

### DIFF
--- a/google-cloud-firestore/clirr-ignored-differences.xml
+++ b/google-cloud-firestore/clirr-ignored-differences.xml
@@ -23,4 +23,17 @@
     <className>com/google/cloud/firestore/Firestore</className>
     <method>com.google.api.core.ApiFuture runAsyncTransaction(*)</method>
   </difference>
+
+  <difference>
+    <differenceType>7005</differenceType>
+    <className>com/google/cloud/firestore/*</className>
+    <method>*(com.google.cloud.firestore.FirestoreImpl, *)</method>
+    <to>*(com.google.cloud.firestore.FirestoreRpcContext, *)</to>
+  </difference>
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/firestore/*</className>
+    <method>*(com.google.cloud.firestore.FirestoreImpl, *)</method>
+  </difference>
+
 </differences>

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
@@ -366,7 +366,8 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<DocumentSnapshot> get(FieldMask fieldMask) {
-    return extractFirst(rpcContext.getFirestore().getAll(new DocumentReference[] {this}, fieldMask));
+    return extractFirst(
+        rpcContext.getFirestore().getAll(new DocumentReference[] {this}, fieldMask));
   }
 
   /**

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
@@ -19,6 +19,7 @@ package com.google.cloud.firestore;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ApiExceptions;
 import com.google.cloud.firestore.v1.FirestoreClient.ListCollectionIdsPagedResponse;
@@ -42,15 +43,16 @@ import javax.annotation.Nullable;
  * test mocks. Subclassing is not supported in production code and new SDK releases may break code
  * that does so.
  */
+@InternalExtensionOnly
 public class DocumentReference {
 
   private final ResourcePath path;
-  private final FirestoreImpl firestore;
+  private final FirestoreRpcContext<?> rpcContext;
 
-  protected DocumentReference(
-      FirestoreImpl firestore, ResourcePath path) { // Elevated access level for mocking.
+  DocumentReference(
+      FirestoreRpcContext<?> rpcContext, ResourcePath path) { // Elevated access level for mocking.
     this.path = path;
-    this.firestore = firestore;
+    this.rpcContext = rpcContext;
   }
 
   /*
@@ -60,7 +62,7 @@ public class DocumentReference {
    */
   @Nonnull
   public Firestore getFirestore() {
-    return firestore;
+    return rpcContext.getFirestore();
   }
 
   /**
@@ -102,7 +104,7 @@ public class DocumentReference {
    */
   @Nonnull
   public CollectionReference getParent() {
-    return new CollectionReference(firestore, path.getParent());
+    return new CollectionReference(rpcContext, path.getParent());
   }
 
   /**
@@ -114,7 +116,7 @@ public class DocumentReference {
    */
   @Nonnull
   public CollectionReference collection(@Nonnull String collectionPath) {
-    return new CollectionReference(firestore, path.append(collectionPath));
+    return new CollectionReference(rpcContext, path.append(collectionPath));
   }
 
   /**
@@ -144,7 +146,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> create(@Nonnull Map<String, Object> fields) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.create(this, fields).commit());
   }
 
@@ -157,7 +159,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> create(@Nonnull Object pojo) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.create(this, pojo).commit());
   }
 
@@ -170,7 +172,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> set(@Nonnull Map<String, Object> fields) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.set(this, fields).commit());
   }
 
@@ -186,7 +188,7 @@ public class DocumentReference {
   @Nonnull
   public ApiFuture<WriteResult> set(
       @Nonnull Map<String, Object> fields, @Nonnull SetOptions options) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.set(this, fields, options).commit());
   }
 
@@ -199,7 +201,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> set(@Nonnull Object pojo) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.set(this, pojo).commit());
   }
 
@@ -214,7 +216,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> set(@Nonnull Object pojo, @Nonnull SetOptions options) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.set(this, pojo, options).commit());
   }
 
@@ -227,7 +229,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> update(@Nonnull Map<String, Object> fields) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.update(this, fields).commit());
   }
 
@@ -241,7 +243,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> update(@Nonnull Map<String, Object> fields, Precondition options) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.update(this, fields, options).commit());
   }
 
@@ -257,7 +259,7 @@ public class DocumentReference {
   @Nonnull
   public ApiFuture<WriteResult> update(
       @Nonnull String field, @Nullable Object value, Object... moreFieldsAndValues) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.update(this, field, value, moreFieldsAndValues).commit());
   }
 
@@ -273,7 +275,7 @@ public class DocumentReference {
   @Nonnull
   public ApiFuture<WriteResult> update(
       @Nonnull FieldPath fieldPath, @Nullable Object value, Object... moreFieldsAndValues) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.update(this, fieldPath, value, moreFieldsAndValues).commit());
   }
 
@@ -293,7 +295,7 @@ public class DocumentReference {
       @Nonnull String field,
       @Nullable Object value,
       Object... moreFieldsAndValues) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(
         writeBatch.update(this, options, field, value, moreFieldsAndValues).commit());
   }
@@ -314,7 +316,7 @@ public class DocumentReference {
       @Nonnull FieldPath fieldPath,
       @Nullable Object value,
       Object... moreFieldsAndValues) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(
         writeBatch.update(this, options, fieldPath, value, moreFieldsAndValues).commit());
   }
@@ -327,7 +329,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> delete(@Nonnull Precondition options) {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.delete(this, options).commit());
   }
 
@@ -338,7 +340,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<WriteResult> delete() {
-    WriteBatch writeBatch = firestore.batch();
+    WriteBatch writeBatch = rpcContext.getFirestore().batch();
     return extractFirst(writeBatch.delete(this).commit());
   }
 
@@ -351,7 +353,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<DocumentSnapshot> get() {
-    return extractFirst(firestore.getAll(this));
+    return extractFirst(rpcContext.getFirestore().getAll(this));
   }
 
   /**
@@ -364,7 +366,7 @@ public class DocumentReference {
    */
   @Nonnull
   public ApiFuture<DocumentSnapshot> get(FieldMask fieldMask) {
-    return extractFirst(firestore.getAll(new DocumentReference[] {this}, fieldMask));
+    return extractFirst(rpcContext.getFirestore().getAll(new DocumentReference[] {this}, fieldMask));
   }
 
   /**
@@ -382,8 +384,8 @@ public class DocumentReference {
     try {
       response =
           ApiExceptions.callAndTranslateApiException(
-              firestore.sendRequest(
-                  request.build(), firestore.getClient().listCollectionIdsPagedCallable()));
+              rpcContext.sendRequest(
+                  request.build(), rpcContext.getClient().listCollectionIdsPagedCallable()));
     } catch (ApiException exception) {
       throw FirestoreException.apiException(exception);
     }
@@ -456,7 +458,7 @@ public class DocumentReference {
                 }
                 listener.onEvent(
                     DocumentSnapshot.fromMissing(
-                        firestore, DocumentReference.this, value.getReadTime()),
+                        rpcContext, DocumentReference.this, value.getReadTime()),
                     null);
               }
             });
@@ -471,7 +473,7 @@ public class DocumentReference {
   @Nonnull
   public ListenerRegistration addSnapshotListener(
       @Nonnull EventListener<DocumentSnapshot> listener) {
-    return addSnapshotListener(firestore.getClient().getExecutor(), listener);
+    return addSnapshotListener(rpcContext.getClient().getExecutor(), listener);
   }
 
   ResourcePath getResourcePath() {
@@ -498,11 +500,11 @@ public class DocumentReference {
       return false;
     }
     DocumentReference that = (DocumentReference) obj;
-    return Objects.equals(path, that.path) && Objects.equals(firestore, that.firestore);
+    return Objects.equals(path, that.path) && Objects.equals(rpcContext, that.rpcContext);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(path, firestore);
+    return Objects.hash(path, rpcContext);
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FieldPath.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FieldPath.java
@@ -19,6 +19,7 @@ package com.google.cloud.firestore;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.firestore.v1.StructuredQuery;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
@@ -30,11 +31,13 @@ import javax.annotation.Nonnull;
 @AutoValue
 public abstract class FieldPath extends BasePath<FieldPath> implements Comparable<FieldPath> {
 
+  private static final String DOCUMENT_ID_SENTINEL = "__name__";
+
   /**
    * A special sentinel FieldPath to refer to the ID of a document. It can be used in queries to
    * sort or filter by the document ID.
    */
-  static final FieldPath DOCUMENT_ID = FieldPath.of("__name__");
+  static final FieldPath DOCUMENT_ID = FieldPath.of(DOCUMENT_ID_SENTINEL);
 
   /** Regular expression to verify that dot-separated field paths do not contain ~*[]/. */
   private static final Pattern PROHIBITED_CHARACTERS = Pattern.compile(".*[~*/\\[\\]].*");
@@ -65,6 +68,11 @@ public abstract class FieldPath extends BasePath<FieldPath> implements Comparabl
    */
   public static FieldPath documentId() {
     return DOCUMENT_ID;
+  }
+
+  /** Verifies if the provided path matches the path that is used for the Document ID sentinel. */
+  static boolean isDocumentId(String path) {
+    return DOCUMENT_ID_SENTINEL.equals(path);
   }
 
   /** Returns a field path from a dot separated string. Does not support escaping. */
@@ -151,5 +159,9 @@ public abstract class FieldPath extends BasePath<FieldPath> implements Comparabl
   @Override
   public String toString() {
     return getEncodedPath();
+  }
+
+  StructuredQuery.FieldReference toProto() {
+    return StructuredQuery.FieldReference.newBuilder().setFieldPath(getEncodedPath()).build();
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -48,7 +48,7 @@ import javax.annotation.Nullable;
  * Main implementation of the Firestore client. This is the entry point for all Firestore
  * operations.
  */
-class FirestoreImpl implements Firestore {
+class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
 
   private static final Random RANDOM = new SecureRandom();
   private static final int AUTO_ID_LENGTH = 20;
@@ -317,34 +317,40 @@ class FirestoreImpl implements Firestore {
   }
 
   /** Returns whether the user has opted into receiving dates as com.google.cloud.Timestamp. */
-  boolean areTimestampsInSnapshotsEnabled() {
+  @Override
+  public boolean areTimestampsInSnapshotsEnabled() {
     return this.firestoreOptions.areTimestampsInSnapshotsEnabled();
   }
 
   /** Returns the name of the Firestore project associated with this client. */
-  String getDatabaseName() {
+  @Override
+  public String getDatabaseName() {
     return databasePath.getDatabaseName().toString();
   }
 
   /** Returns a path to the Firestore project associated with this client. */
-  ResourcePath getResourcePath() {
+  @Override
+  public ResourcePath getResourcePath() {
     return databasePath;
   }
 
   /** Returns the underlying RPC client. */
-  FirestoreRpc getClient() {
+  @Override
+  public FirestoreRpc getClient() {
     return firestoreClient;
   }
 
   /** Request funnel for all read/write requests. */
-  <RequestT, ResponseT> ApiFuture<ResponseT> sendRequest(
+  @Override
+  public <RequestT, ResponseT> ApiFuture<ResponseT> sendRequest(
       RequestT requestT, UnaryCallable<RequestT, ResponseT> callable) {
     Preconditions.checkState(!closed, "Firestore client has already been closed");
     return callable.futureCall(requestT);
   }
 
   /** Request funnel for all unidirectional streaming requests. */
-  <RequestT, ResponseT> void streamRequest(
+  @Override
+  public <RequestT, ResponseT> void streamRequest(
       RequestT requestT,
       ApiStreamObserver<ResponseT> responseObserverT,
       ServerStreamingCallable<RequestT, ResponseT> callable) {
@@ -353,11 +359,17 @@ class FirestoreImpl implements Firestore {
   }
 
   /** Request funnel for all bidirectional streaming requests. */
-  <RequestT, ResponseT> ApiStreamObserver<RequestT> streamRequest(
+  @Override
+  public <RequestT, ResponseT> ApiStreamObserver<RequestT> streamRequest(
       ApiStreamObserver<ResponseT> responseObserverT,
       BidiStreamingCallable<RequestT, ResponseT> callable) {
     Preconditions.checkState(!closed, "Firestore client has already been closed");
     return callable.bidiStreamingCall(responseObserverT);
+  }
+
+  @Override
+  public FirestoreImpl getFirestore() {
+    return this;
   }
 
   @Override

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreRpcContext.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreRpcContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.firestore.spi.v1.FirestoreRpc;
+
+@InternalApi
+@InternalExtensionOnly
+interface FirestoreRpcContext<FS extends Firestore> {
+
+  FS getFirestore();
+
+  boolean areTimestampsInSnapshotsEnabled();
+
+  String getDatabaseName();
+
+  ResourcePath getResourcePath();
+
+  FirestoreRpc getClient();
+
+  <RequestT, ResponseT> ApiFuture<ResponseT> sendRequest(
+      RequestT requestT, UnaryCallable<RequestT, ResponseT> callable);
+
+  <RequestT, ResponseT> void streamRequest(
+      RequestT requestT,
+      ApiStreamObserver<ResponseT> responseObserverT,
+      ServerStreamingCallable<RequestT, ResponseT> callable);
+
+  <RequestT, ResponseT> ApiStreamObserver<RequestT> streamRequest(
+      ApiStreamObserver<ResponseT> responseObserverT,
+      BidiStreamingCallable<RequestT, ResponseT> callable);
+}

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/QueryDocumentSnapshot.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/QueryDocumentSnapshot.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.firestore;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.Timestamp;
 import com.google.common.base.Preconditions;
 import com.google.firestore.v1.Document;
@@ -36,22 +37,23 @@ import javax.annotation.Nonnull;
  * test mocks. Subclassing is not supported in production code and new SDK releases may break code
  * that does so.
  */
+@InternalExtensionOnly
 public class QueryDocumentSnapshot extends DocumentSnapshot {
-  protected QueryDocumentSnapshot(
-      FirestoreImpl firestore,
+  QueryDocumentSnapshot(
+      FirestoreRpcContext<?> rpcContext,
       DocumentReference docRef,
       Map<String, Value> fields,
       Timestamp readTime,
       Timestamp updateTime,
       Timestamp createTime) { // Elevated access level for mocking.
-    super(firestore, docRef, fields, readTime, updateTime, createTime);
+    super(rpcContext, docRef, fields, readTime, updateTime, createTime);
   }
 
   static QueryDocumentSnapshot fromDocument(
-      FirestoreImpl firestore, Timestamp readTime, Document document) {
+      FirestoreRpcContext<?> rpcContext, Timestamp readTime, Document document) {
     return new QueryDocumentSnapshot(
-        firestore,
-        new DocumentReference(firestore, ResourcePath.create(document.getName())),
+        rpcContext,
+        new DocumentReference(rpcContext, ResourcePath.create(document.getName())),
         document.getFieldsMap(),
         readTime,
         Timestamp.fromProto(document.getUpdateTime()),

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/ResourcePath.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/ResourcePath.java
@@ -55,7 +55,7 @@ abstract class ResourcePath extends BasePath<ResourcePath> {
   static ResourcePath create(String resourceName) {
     String[] parts = resourceName.split("/");
 
-    if (parts.length >= 6 && parts[0].equals("projects") && parts[2].equals("databases")) {
+    if (parts.length >= 5 && parts[0].equals("projects") && parts[2].equals("databases")) {
       String[] path = Arrays.copyOfRange(parts, 5, parts.length);
       return create(
           DatabaseRootName.of(parts[1], parts[3]),

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -37,13 +37,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 
-import com.google.api.client.util.Base64;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.Query.ComparisonFilter;
 import com.google.cloud.firestore.Query.FieldFilter;
 import com.google.cloud.firestore.spi.v1.FirestoreRpc;
+import com.google.common.io.BaseEncoding;
 import com.google.firestore.v1.ArrayValue;
 import com.google.firestore.v1.RunQueryRequest;
 import com.google.firestore.v1.StructuredQuery;
@@ -935,11 +935,11 @@ public class QueryTest {
     // Code used to generate the below base64 encoded RunQueryRequest
     // RunQueryRequest proto = firestoreMock.collection("testing-collection")
     //     .whereEqualTo("enabled", true).toProto();
-    // String base64String = Base64.encodeBase64String(proto.toByteArray());
+    // String base64String = BaseEncoding.base64().encode(proto.toByteArray());
     String base64Proto =
         "CjNwcm9qZWN0cy90ZXN0LXByb2plY3QvZGF0YWJhc2VzLyhkZWZhdWx0KS9kb2N1bWVudHMSKxIUEhJ0ZXN0aW5nLWNvbGxlY3Rpb24aExIRCgkSB2VuYWJsZWQQBRoCCAE=";
 
-    byte[] bytes = Base64.decodeBase64(base64Proto);
+    byte[] bytes = BaseEncoding.base64().decode(base64Proto);
     RunQueryRequest runQueryRequest = RunQueryRequest.parseFrom(bytes);
 
     Query query = Query.fromProto((Firestore) o, runQueryRequest);

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -58,6 +58,7 @@ import com.google.cloud.firestore.WriteResult;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.firestore.v1.RunQueryRequest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1259,5 +1260,13 @@ public class ITSystemTest {
     assertEquals(ref2.getId(), documentSnapshots.get(1).getId());
     assertEquals(ref3.getId(), documentSnapshots.get(2).getId());
     assertEquals(3, documentSnapshots.size());
+  }
+
+  @Test
+  public void testInstanceReturnedByGetServiceCanBeUsedToDeserializeAQuery() throws Exception {
+    Firestore fs = FirestoreOptions.getDefaultInstance().getService();
+    RunQueryRequest proto = fs.collection("coll").whereEqualTo("bob", "alice").toProto();
+    fs.close();
+    Query.fromProto(fs, proto);
   }
 }


### PR DESCRIPTION
 This PR adds an API to serialize and deserialize Queries to and from RunQueryRequests. The new API endpoints are `Query.toProto` and `Query.fromProto`.
