### PR TITLE
fix: add BulkWriter system tests + pass BE error messages

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BatchWriteResult.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BatchWriteResult.java
@@ -44,5 +44,7 @@ public final class BatchWriteResult {
     return status;
   }
 
-  public String getMessage() { return message; }
+  public String getMessage() {
+    return message;
+  }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BatchWriteResult.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BatchWriteResult.java
@@ -27,10 +27,12 @@ import javax.annotation.Nullable;
 public final class BatchWriteResult {
   @Nullable private final Timestamp writeTime;
   private final Status status;
+  private final String message;
 
-  BatchWriteResult(@Nullable Timestamp timestamp, Status status) {
+  BatchWriteResult(@Nullable Timestamp timestamp, Status status, String message) {
     this.writeTime = timestamp;
     this.status = status;
+    this.message = message;
   }
 
   @Nullable
@@ -41,4 +43,6 @@ public final class BatchWriteResult {
   public Status getStatus() {
     return status;
   }
+
+  public String getMessage() { return message; }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -764,7 +764,8 @@ public abstract class UpdateBuilder<T> {
     if (result.getWriteTime() != null) {
       future.set(new WriteResult(result.getWriteTime()));
     } else {
-      future.setException(FirestoreException.serverRejected(result.getStatus(), result.getMessage() ));
+      future.setException(
+          FirestoreException.serverRejected(result.getStatus(), result.getMessage()));
     }
   }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -700,7 +700,7 @@ public abstract class UpdateBuilder<T> {
               Status code = Status.fromCodeValue(status.getCode());
               Timestamp updateTime =
                   code == Status.OK ? Timestamp.fromProto(writeResult.getUpdateTime()) : null;
-              result.add(new BatchWriteResult(updateTime, code));
+              result.add(new BatchWriteResult(updateTime, code, status.getMessage()));
             }
 
             return result;
@@ -764,7 +764,7 @@ public abstract class UpdateBuilder<T> {
     if (result.getWriteTime() != null) {
       future.set(new WriteResult(result.getWriteTime()));
     } else {
-      future.setException(FirestoreException.serverRejected(result.getStatus(), "Backend error"));
+      future.setException(FirestoreException.serverRejected(result.getStatus(), result.getMessage() ));
     }
   }
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -1261,6 +1261,24 @@ public class ITSystemTest {
         writer.create(docRef, Collections.singletonMap("foo", (Object) "bar"));
     writer.close().get();
     assertNotNull(result.get().getUpdateTime());
+    DocumentSnapshot snapshot = docRef.get().get();
+    assertEquals("bar", snapshot.get("foo"));
+  }
+
+  @Test
+  public void bulkWriterCreateAddsPrecondition() throws Exception {
+    DocumentReference docRef = randomColl.document();
+    docRef.set(Collections.singletonMap("foo", (Object) "bar")).get();
+    BulkWriter writer = firestore.bulkWriter();
+    ApiFuture<WriteResult> result =
+        writer.create(docRef, Collections.singletonMap("foo", (Object) "bar"));
+    writer.close().get();
+    try {
+      result.get();
+      fail("Create operation should have thrown exception");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("Document already exists"));
+    }
   }
 
   @Test
@@ -1271,6 +1289,8 @@ public class ITSystemTest {
         writer.set(docRef, Collections.singletonMap("foo", (Object) "bar"));
     writer.close().get();
     assertNotNull(result.get().getUpdateTime());
+    DocumentSnapshot snapshot = docRef.get().get();
+    assertEquals("bar", snapshot.get("foo"));
   }
 
   @Test
@@ -1282,6 +1302,23 @@ public class ITSystemTest {
         writer.update(docRef, Collections.singletonMap("foo", (Object) "bar"));
     writer.close().get();
     assertNotNull(result.get().getUpdateTime());
+    DocumentSnapshot snapshot = docRef.get().get();
+    assertEquals("bar", snapshot.get("foo"));
+  }
+
+  @Test
+  public void bulkWriterUpdateAddsPrecondition() throws Exception {
+    DocumentReference docRef = randomColl.document();
+    BulkWriter writer = firestore.bulkWriter();
+    ApiFuture<WriteResult> result =
+        writer.update(docRef, Collections.singletonMap("foo", (Object) "bar"));
+    writer.close().get();
+    try {
+      result.get();
+      fail("Update operation should have thrown exception");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("No document to update"));
+    }
   }
 
   @Test
@@ -1294,6 +1331,8 @@ public class ITSystemTest {
     assertNotNull(result.get().getUpdateTime());
     // TODO(b/158502664): Remove this check once we can get write times.
     assertEquals(Timestamp.ofTimeSecondsAndNanos(0, 0), result.get().getUpdateTime());
+    DocumentSnapshot snapshot = docRef.get().get();
+    assertNull(snapshot.get("foo"));
   }
 
   @Test

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -1256,10 +1256,12 @@ public class ITSystemTest {
   @Test
   public void bulkWriterCreate() throws Exception {
     DocumentReference docRef = randomColl.document();
+
     BulkWriter writer = firestore.bulkWriter();
     ApiFuture<WriteResult> result =
         writer.create(docRef, Collections.singletonMap("foo", (Object) "bar"));
     writer.close().get();
+
     assertNotNull(result.get().getUpdateTime());
     DocumentSnapshot snapshot = docRef.get().get();
     assertEquals("bar", snapshot.get("foo"));
@@ -1269,10 +1271,12 @@ public class ITSystemTest {
   public void bulkWriterCreateAddsPrecondition() throws Exception {
     DocumentReference docRef = randomColl.document();
     docRef.set(Collections.singletonMap("foo", (Object) "bar")).get();
+
     BulkWriter writer = firestore.bulkWriter();
     ApiFuture<WriteResult> result =
         writer.create(docRef, Collections.singletonMap("foo", (Object) "bar"));
     writer.close().get();
+
     try {
       result.get();
       fail("Create operation should have thrown exception");
@@ -1284,10 +1288,12 @@ public class ITSystemTest {
   @Test
   public void bulkWriterSet() throws Exception {
     DocumentReference docRef = randomColl.document();
+
     BulkWriter writer = firestore.bulkWriter();
     ApiFuture<WriteResult> result =
         writer.set(docRef, Collections.singletonMap("foo", (Object) "bar"));
     writer.close().get();
+
     assertNotNull(result.get().getUpdateTime());
     DocumentSnapshot snapshot = docRef.get().get();
     assertEquals("bar", snapshot.get("foo"));
@@ -1296,23 +1302,25 @@ public class ITSystemTest {
   @Test
   public void bulkWriterUpdate() throws Exception {
     DocumentReference docRef = randomColl.document();
-    docRef.set(Collections.singletonMap("foo", "bar0")).get();
+    docRef.set(Collections.singletonMap("foo", "oldValue")).get();
+
     BulkWriter writer = firestore.bulkWriter();
-    ApiFuture<WriteResult> result =
-        writer.update(docRef, Collections.singletonMap("foo", (Object) "bar"));
+    ApiFuture<WriteResult> result = writer.update(docRef, "foo", "newValue");
     writer.close().get();
+
     assertNotNull(result.get().getUpdateTime());
     DocumentSnapshot snapshot = docRef.get().get();
-    assertEquals("bar", snapshot.get("foo"));
+    assertEquals("newValue", snapshot.get("foo"));
   }
 
   @Test
   public void bulkWriterUpdateAddsPrecondition() throws Exception {
     DocumentReference docRef = randomColl.document();
+
     BulkWriter writer = firestore.bulkWriter();
-    ApiFuture<WriteResult> result =
-        writer.update(docRef, Collections.singletonMap("foo", (Object) "bar"));
+    ApiFuture<WriteResult> result = writer.update(docRef, "foo", "newValue");
     writer.close().get();
+
     try {
       result.get();
       fail("Update operation should have thrown exception");
@@ -1324,10 +1332,12 @@ public class ITSystemTest {
   @Test
   public void bulkWriterDelete() throws Exception {
     DocumentReference docRef = randomColl.document();
-    docRef.set(Collections.singletonMap("foo", "bar0")).get();
+    docRef.set(Collections.singletonMap("foo", "oldValue")).get();
+
     BulkWriter writer = firestore.bulkWriter();
     ApiFuture<WriteResult> result = writer.delete(docRef);
     writer.close().get();
+
     assertNotNull(result.get().getUpdateTime());
     // TODO(b/158502664): Remove this check once we can get write times.
     assertEquals(Timestamp.ofTimeSecondsAndNanos(0, 0), result.get().getUpdateTime());
@@ -1338,12 +1348,14 @@ public class ITSystemTest {
   @Test
   public void bulkWriterWritesInOrder() throws Exception {
     DocumentReference docRef = randomColl.document();
-    docRef.set(Collections.singletonMap("foo", "bar0")).get();
+    docRef.set(Collections.singletonMap("foo", "oldValue")).get();
+
     BulkWriter writer = firestore.bulkWriter();
     writer.set(docRef, Collections.singletonMap("foo", (Object) "bar1"));
     writer.set(docRef, Collections.singletonMap("foo", (Object) "bar2"));
     writer.set(docRef, Collections.singletonMap("foo", (Object) "bar3"));
     writer.close().get();
+
     ApiFuture<DocumentSnapshot> result = docRef.get();
     assertEquals(Collections.singletonMap("foo", "bar3"), result.get().getData());
   }


### PR DESCRIPTION
Porting integration tests from [node](https://github.com/googleapis/nodejs-firestore/pull/1117).

After running into a few BE contention errors during testing, I also added the error message to `BatchWriteResult`, since backend errors were not being returned in a useful manner.