### PR TITLE
chore!: remove deprecated getCollections() methods

### DIFF
--- a/google-cloud-firestore/clirr-ignored-differences.xml
+++ b/google-cloud-firestore/clirr-ignored-differences.xml
@@ -17,23 +17,17 @@
 
 <!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
 <differences>
-  <!-- TODO: Remove after release of 1.33.0 -->
-  <difference>
-    <differenceType>7012</differenceType>
-    <className>com/google/cloud/firestore/Firestore</className>
-    <method>com.google.api.core.ApiFuture runAsyncTransaction(*)</method>
-  </difference>
 
+  <!-- v2.0.0 -->
   <difference>
-    <differenceType>7005</differenceType>
-    <className>com/google/cloud/firestore/*</className>
-    <method>*(com.google.cloud.firestore.FirestoreImpl, *)</method>
-    <to>*(com.google.cloud.firestore.FirestoreRpcContext, *)</to>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/firestore/DocumentReference</className>
+    <method>java.lang.Iterable getCollections()</method>
   </difference>
   <difference>
-    <differenceType>7009</differenceType>
-    <className>com/google/cloud/firestore/*</className>
-    <method>*(com.google.cloud.firestore.FirestoreImpl, *)</method>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/firestore/Firestore</className>
+    <method>java.lang.Iterable getCollections()</method>
   </difference>
 
   <!--

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
@@ -417,19 +417,6 @@ public class DocumentReference {
   }
 
   /**
-   * Fetches the subcollections that are direct children of this document.
-   *
-   * @deprecated Use {@link #listCollections()}.
-   * @throws FirestoreException if the Iterable could not be initialized.
-   * @return An Iterable that can be used to fetch all subcollections.
-   */
-  @Deprecated
-  @Nonnull
-  public Iterable<CollectionReference> getCollections() {
-    return listCollections();
-  }
-
-  /**
    * Starts listening to the document referenced by this DocumentReference.
    *
    * @param executor The executor to use to call the listener.

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Firestore.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Firestore.java
@@ -56,17 +56,6 @@ public interface Firestore extends Service<FirestoreOptions>, AutoCloseable {
   Iterable<CollectionReference> listCollections();
 
   /**
-   * Fetches the root collections that are associated with this Firestore database.
-   *
-   * @deprecated Use {@link #listCollections()}.
-   * @throws FirestoreException if the Iterable could not be initialized.
-   * @return An Iterable that can be used to fetch all collections.
-   */
-  @Deprecated
-  @Nonnull
-  Iterable<CollectionReference> getCollections();
-
-  /**
    * Creates and returns a new @link{Query} that includes all documents in the database that are
    * contained in a collection or subcollection with the given @code{collectionId}.
    *

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -122,12 +122,6 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
 
   @Nonnull
   @Override
-  public Iterable<CollectionReference> getCollections() {
-    return listCollections();
-  }
-
-  @Nonnull
-  @Override
   public ApiFuture<List<DocumentSnapshot>> getAll(
       @Nonnull DocumentReference... documentReferences) {
     return this.getAll(documentReferences, null, (ByteString) null);


### PR DESCRIPTION
* Remove deprecated Firestore#getCollections() method. Use Firestore#listCollections() instead
* Remove deprecated DocumentReference#getCollections() method. Use DocumentReference#listCollections() instead

