### PR TITLE
feat: add support for read-only transactions in TransactionOptions

### DIFF
--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -152,6 +152,12 @@
       <version>2.11.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.11</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <reporting>

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -30,7 +30,6 @@ import com.google.firestore.v1.BatchGetDocumentsRequest;
 import com.google.firestore.v1.BatchGetDocumentsResponse;
 import com.google.firestore.v1.DatabaseRootName;
 import com.google.protobuf.ByteString;
-import io.grpc.Context;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
@@ -40,7 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.Executor;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -310,15 +308,9 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
   public <T> ApiFuture<T> runAsyncTransaction(
       @Nonnull final Transaction.AsyncFunction<T> updateFunction,
       @Nonnull TransactionOptions transactionOptions) {
-    final Executor userCallbackExecutor =
-        Context.currentContextExecutor(
-            transactionOptions.getExecutor() != null
-                ? transactionOptions.getExecutor()
-                : firestoreClient.getExecutor());
 
     TransactionRunner<T> transactionRunner =
-        new TransactionRunner<>(
-            this, updateFunction, userCallbackExecutor, transactionOptions.getNumberOfAttempts());
+        new TransactionRunner<>(this, updateFunction, transactionOptions);
     return transactionRunner.run();
   }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -63,7 +63,7 @@ public final class Transaction extends UpdateBuilder<Transaction> {
     ApiFuture<T> updateCallback(Transaction transaction);
   }
 
-  private final TransactionOptions originalTransactionOptions;
+  private final TransactionOptions transactionOptions;
   @Nullable private final ByteString previousTransactionId;
   private ByteString transactionId;
 
@@ -72,7 +72,7 @@ public final class Transaction extends UpdateBuilder<Transaction> {
       TransactionOptions transactionOptions,
       @Nullable Transaction previousTransaction) {
     super(firestore);
-    this.originalTransactionOptions = transactionOptions;
+    this.transactionOptions = transactionOptions;
     this.previousTransactionId =
         previousTransaction != null ? previousTransaction.transactionId : null;
   }
@@ -86,14 +86,14 @@ public final class Transaction extends UpdateBuilder<Transaction> {
     BeginTransactionRequest.Builder beginTransaction = BeginTransactionRequest.newBuilder();
     beginTransaction.setDatabase(firestore.getDatabaseName());
 
-    if (originalTransactionOptions.getType() == TransactionOptionsType.READ_WRITE
+    if (transactionOptions.getType() == TransactionOptionsType.READ_WRITE
         && previousTransactionId != null) {
       beginTransaction
           .getOptionsBuilder()
           .getReadWriteBuilder()
           .setRetryTransaction(previousTransactionId);
-    } else if (originalTransactionOptions.getType() == TransactionOptionsType.READ_ONLY) {
-      final ReadOnly.Builder builder = originalTransactionOptions.getReadOnly().toProtoBuilder();
+    } else if (transactionOptions.getType() == TransactionOptionsType.READ_ONLY) {
+      final ReadOnly.Builder builder = transactionOptions.getReadOnly().toProtoBuilder();
       beginTransaction.getOptionsBuilder().setReadOnly(builder);
     }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.firestore.v1.BeginTransactionRequest;
 import com.google.firestore.v1.BeginTransactionResponse;
 import com.google.firestore.v1.RollbackRequest;
+import com.google.firestore.v1.TransactionOptions.ReadOnly;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import java.util.List;
@@ -91,12 +92,12 @@ public final class Transaction extends UpdateBuilder<Transaction> {
           .getOptionsBuilder()
           .getReadWriteBuilder()
           .setRetryTransaction(previousTransactionId);
-    } else if (TransactionOptionsType.READ_ONLY.equals(transactionOptions.getType())
-        && transactionOptions.getReadTime() != null) {
-      beginTransaction
-          .getOptionsBuilder()
-          .getReadOnlyBuilder()
-          .setReadTime(transactionOptions.getReadTime());
+    } else if (TransactionOptionsType.READ_ONLY.equals(transactionOptions.getType())) {
+      final ReadOnly.Builder readOnlyBuilder = ReadOnly.newBuilder();
+      if (transactionOptions.getReadTime() != null) {
+        readOnlyBuilder.setReadTime(transactionOptions.getReadTime());
+      }
+      beginTransaction.getOptionsBuilder().setReadOnly(readOnlyBuilder);
     }
 
     ApiFuture<BeginTransactionResponse> transactionBeginFuture =

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.firestore.v1.BeginTransactionRequest;
 import com.google.firestore.v1.BeginTransactionResponse;
 import com.google.firestore.v1.RollbackRequest;
-import com.google.firestore.v1.TransactionOptions.ReadOnly;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import java.util.List;
@@ -92,9 +91,8 @@ public final class Transaction extends UpdateBuilder<Transaction> {
           .getOptionsBuilder()
           .getReadWriteBuilder()
           .setRetryTransaction(previousTransactionId);
-    } else if (TransactionOptionsType.READ_ONLY.equals(transactionOptions.getType())) {
-      final ReadOnly builder = transactionOptions.getReadOnly().toProto();
-      beginTransaction.getOptionsBuilder().setReadOnly(builder);
+    } else if (TransactionOptionsType.READ_ONLY.equals(transactionOptions.getType()) && transactionOptions.getReadTime()!= null) {
+        beginTransaction.getOptionsBuilder().getReadOnlyBuilder().setReadTime(transactionOptions.getReadTime());
     }
 
     ApiFuture<BeginTransactionResponse> transactionBeginFuture =

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -86,13 +86,13 @@ public final class Transaction extends UpdateBuilder<Transaction> {
     BeginTransactionRequest.Builder beginTransaction = BeginTransactionRequest.newBuilder();
     beginTransaction.setDatabase(firestore.getDatabaseName());
 
-    if (transactionOptions.getType() == TransactionOptionsType.READ_WRITE
+    if (TransactionOptionsType.READ_WRITE.equals(transactionOptions.getType())
         && previousTransactionId != null) {
       beginTransaction
           .getOptionsBuilder()
           .getReadWriteBuilder()
           .setRetryTransaction(previousTransactionId);
-    } else if (transactionOptions.getType() == TransactionOptionsType.READ_ONLY) {
+    } else if (TransactionOptionsType.READ_ONLY.equals(transactionOptions.getType())) {
       final ReadOnly.Builder builder = transactionOptions.getReadOnly().toProtoBuilder();
       beginTransaction.getOptionsBuilder().setReadOnly(builder);
     }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -19,7 +19,6 @@ package com.google.cloud.firestore;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.cloud.firestore.TransactionOptions.EitherReadOnlyOrReadWrite;
 import com.google.cloud.firestore.TransactionOptions.TransactionOptionsType;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -87,14 +86,13 @@ public final class Transaction extends UpdateBuilder<Transaction> {
     BeginTransactionRequest.Builder beginTransaction = BeginTransactionRequest.newBuilder();
     beginTransaction.setDatabase(firestore.getDatabaseName());
 
-    final EitherReadOnlyOrReadWrite options = originalTransactionOptions.getOptions();
-    if (options.getType() == TransactionOptionsType.READ_WRITE && previousTransactionId != null) {
+    if (originalTransactionOptions.getType() == TransactionOptionsType.READ_WRITE && previousTransactionId != null) {
       beginTransaction
           .getOptionsBuilder()
           .getReadWriteBuilder()
           .setRetryTransaction(previousTransactionId);
-    } else if (options.getType() == TransactionOptionsType.READ_ONLY) {
-      final ReadOnly.Builder builder = options.getReadOnly().toProtoBuilder();
+    } else if (originalTransactionOptions.getType() == TransactionOptionsType.READ_ONLY) {
+      final ReadOnly.Builder builder = originalTransactionOptions.getReadOnly().toProtoBuilder();
       beginTransaction.getOptionsBuilder().setReadOnly(builder);
     }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -93,7 +93,7 @@ public final class Transaction extends UpdateBuilder<Transaction> {
           .getReadWriteBuilder()
           .setRetryTransaction(previousTransactionId);
     } else if (TransactionOptionsType.READ_ONLY.equals(transactionOptions.getType())) {
-      final ReadOnly.Builder builder = transactionOptions.getReadOnly().toProtoBuilder();
+      final ReadOnly builder = transactionOptions.getReadOnly().toProto();
       beginTransaction.getOptionsBuilder().setReadOnly(builder);
     }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -86,7 +86,8 @@ public final class Transaction extends UpdateBuilder<Transaction> {
     BeginTransactionRequest.Builder beginTransaction = BeginTransactionRequest.newBuilder();
     beginTransaction.setDatabase(firestore.getDatabaseName());
 
-    if (originalTransactionOptions.getType() == TransactionOptionsType.READ_WRITE && previousTransactionId != null) {
+    if (originalTransactionOptions.getType() == TransactionOptionsType.READ_WRITE
+        && previousTransactionId != null) {
       beginTransaction
           .getOptionsBuilder()
           .getReadWriteBuilder()

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -91,8 +91,12 @@ public final class Transaction extends UpdateBuilder<Transaction> {
           .getOptionsBuilder()
           .getReadWriteBuilder()
           .setRetryTransaction(previousTransactionId);
-    } else if (TransactionOptionsType.READ_ONLY.equals(transactionOptions.getType()) && transactionOptions.getReadTime()!= null) {
-        beginTransaction.getOptionsBuilder().getReadOnlyBuilder().setReadTime(transactionOptions.getReadTime());
+    } else if (TransactionOptionsType.READ_ONLY.equals(transactionOptions.getType())
+        && transactionOptions.getReadTime() != null) {
+      beginTransaction
+          .getOptionsBuilder()
+          .getReadOnlyBuilder()
+          .setReadTime(transactionOptions.getReadTime());
     }
 
     ApiFuture<BeginTransactionResponse> transactionBeginFuture =

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
@@ -43,9 +43,9 @@ public final class TransactionOptions {
   }
 
   /**
-   * @return int Representing the initial number of attempts a read-write transaction will be
+   * @return the initial number of attempts a read-write transaction will be
    *     attempted
-   * @deprecated As of v2.0.0, only applicable to Read-Write transactions. Use {@link
+   * @deprecated as of v2.0.0, only applicable to Read-Write transactions. Use {@link
    *     ReadWriteOptions#getNumberOfAttempts()} instead
    */
   @Deprecated
@@ -58,7 +58,7 @@ public final class TransactionOptions {
     }
   }
 
-  /** @return Executor Executor to be used to run user callbacks on */
+  /** @return Executor to be used to run user callbacks on */
   @Nullable
   public Executor getExecutor() {
     return executor;
@@ -71,8 +71,7 @@ public final class TransactionOptions {
   }
 
   /**
-   * Create a default set of ReadWrite options suitable for most use cases. Transactions will be
-   * attempted 5 times.
+   * Create a default set of options suitable for most use cases. Transactions will be opened as ReadWrite transactions and attempted up to 5 times.
    *
    * @return The TransactionOptions object.
    * @see #readWriteOptionsBuilder()
@@ -87,7 +86,7 @@ public final class TransactionOptions {
    *
    * @param numberOfAttempts The number of execution attempts.
    * @return The TransactionOptions object.
-   * @deprecated As of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setNumberOfAttempts(int)}
+   * @deprecated as of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setNumberOfAttempts(int)}
    * @see #readWriteOptionsBuilder()
    */
   @Nonnull
@@ -101,7 +100,7 @@ public final class TransactionOptions {
    *
    * @param executor The executor to run the user callback code on.
    * @return The TransactionOptions object.
-   * @deprecated As of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setExecutor(Executor)}
+   * @deprecated as of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setExecutor(Executor)}
    * @see #readWriteOptionsBuilder()
    */
   @Nonnull
@@ -116,7 +115,7 @@ public final class TransactionOptions {
    * @param executor The executor to run the user callback code on.
    * @param numberOfAttempts The number of execution attempts.
    * @return The TransactionOptions object.
-   * @deprecated As of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setExecutor(Executor)} and
+   * @deprecated as of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setExecutor(Executor)} and
    *     {@link ReadWriteOptionsBuilder#setNumberOfAttempts(int)}
    * @see #readWriteOptionsBuilder()
    */

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
@@ -29,10 +29,10 @@ import javax.annotation.Nullable;
  *
  * <p>A transaction in Firestore can be either read-write or read-only.
  *
- * <p>The default set of options is a read-write transaction with a max attempt count of 5. This
- * attempt count can be customized via the {@link ReadWriteOptionsBuilder#setNumberOfAttempts(int)}
- * method. A new instance of a builder can be created by calling {@link
- * #createReadWriteOptionsBuilder()}.
+ * <p>The default set of options is a read-write transaction with a maximum number of 5 attempts.
+ * This attempt count can be customized via the {@link
+ * ReadWriteOptionsBuilder#setNumberOfAttempts(int)} method. A new instance of a builder can be
+ * created by calling {@link #createReadWriteOptionsBuilder()}.
  *
  * <p>A read-only transaction can be configured via the {@link ReadOnlyOptionsBuilder} class. A new
  * instance can be created by calling {@link #createReadOnlyOptionsBuilder()}.
@@ -49,8 +49,7 @@ public final class TransactionOptions {
   private final Executor executor;
   private final TransactionOptionsType type;
   private final int numberOfAttempts;
-  @Nullable
-  private final Timestamp readTime;
+  @Nullable private final Timestamp readTime;
 
   TransactionOptions(
       Executor executor,
@@ -64,7 +63,10 @@ public final class TransactionOptions {
   }
 
   /**
-   * @return the initial number of attempts a read-write transaction will be attempted
+   * Returns the maximum number of times a transaction will be attempted before resulting in an
+   * error.
+   *
+   * @return The max number of attempts to try and commit the transaction.
    */
   public int getNumberOfAttempts() {
     return numberOfAttempts;
@@ -87,8 +89,10 @@ public final class TransactionOptions {
   }
 
   /**
-   * Specify to read documents at the given time. This may not be more than 60 in the past from
-   * when the request is processed by the server.
+   * A {@link Timestamp} specifying the time documents are to be read at. If null, the server will
+   * read documents at the most up to date available. If nonnull, the specified {@code Timestamp}
+   * may not be more than 60 seconds in the past (evaluated when the request is processed by the
+   * server).
    *
    * @return The specific time to read documents at. A null value means read most up to date data.
    */
@@ -161,7 +165,7 @@ public final class TransactionOptions {
   }
 
   /**
-   * @return a new builder with default values applicable to configuring options for a read-write
+   * @return a new Builder with default values applicable to configuring options for a read-write
    *     transaction.
    */
   @Nonnull
@@ -170,7 +174,7 @@ public final class TransactionOptions {
   }
 
   /**
-   * @return a new builder with default values applicable to configuring options for a read-only
+   * @return a new Builder with default values applicable to configuring options for a read-only
    *     transaction.
    */
   @Nonnull
@@ -232,8 +236,8 @@ public final class TransactionOptions {
     }
 
     /**
-     * Specify to read documents at the given time. This may not be more than 60 in the past from
-     * when the request is processed by the server.
+     * Specify to read documents at the given time. This may not be more than 60 seconds in the past
+     * from when the request is processed by the server.
      *
      * @param readTime The specific time to read documents at. Must not be older than 60 seconds. A
      *     null value means read most up to date data.
@@ -254,8 +258,7 @@ public final class TransactionOptions {
       } else {
         timestamp = (Timestamp) readTime;
       }
-      return new TransactionOptions(
-          executor, TransactionOptionsType.READ_ONLY, 1, timestamp);
+      return new TransactionOptions(executor, TransactionOptionsType.READ_ONLY, 1, timestamp);
     }
   }
 
@@ -302,10 +305,7 @@ public final class TransactionOptions {
     @Override
     public TransactionOptions build() {
       return new TransactionOptions(
-          executor,
-          TransactionOptionsType.READ_WRITE,
-          numberOfAttempts,
-          null);
+          executor, TransactionOptionsType.READ_WRITE, numberOfAttempts, null);
     }
   }
 
@@ -313,5 +313,4 @@ public final class TransactionOptions {
     READ_ONLY,
     READ_WRITE
   }
-
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
@@ -72,22 +72,19 @@ public final class TransactionOptions {
   }
 
   @Nonnull
-  @InternalApi
-  TransactionOptionsType getType() {
+  public TransactionOptionsType getType() {
     return type;
   }
 
   @Nonnull
-  @InternalApi
-  ReadOnlyOptions getReadOnly() {
+  public ReadOnlyOptions getReadOnly() {
     Preconditions.checkState(
         readOnly != null && readWrite == null, "Unable to call getReadOnly for ReadWriteOptions");
     return readOnly;
   }
 
   @Nonnull
-  @InternalApi
-  ReadWriteOptions getReadWrite() {
+  public ReadWriteOptions getReadWrite() {
     Preconditions.checkState(
         readWrite != null && readOnly == null, "Unable to call getReadWrite for ReadOnlyOptions");
     return readWrite;
@@ -162,7 +159,7 @@ public final class TransactionOptions {
     return Builder.readOnlyBuilder();
   }
 
-  public abstract static class Builder<T, B extends Builder<T, B>> {
+  public abstract static class Builder<B extends Builder<B>> {
     @Nullable protected Executor executor;
 
     protected Builder(@Nullable Executor executor) {
@@ -193,8 +190,7 @@ public final class TransactionOptions {
     }
   }
 
-  public static final class ReadOnlyOptionsBuilder
-      extends Builder<ReadOnlyOptions, ReadOnlyOptionsBuilder> {
+  public static final class ReadOnlyOptionsBuilder extends Builder<ReadOnlyOptionsBuilder> {
     @Nullable private TimestampOrBuilder readTime;
 
     private ReadOnlyOptionsBuilder(@Nullable Executor executor, @Nullable Timestamp readTime) {
@@ -226,8 +222,7 @@ public final class TransactionOptions {
     }
   }
 
-  public static final class ReadWriteOptionsBuilder
-      extends Builder<ReadWriteOptions, ReadWriteOptionsBuilder> {
+  public static final class ReadWriteOptionsBuilder extends Builder<ReadWriteOptionsBuilder> {
     private int numberOfAttempts;
 
     private ReadWriteOptionsBuilder(@Nullable Executor executor, int numberOfAttempts) {
@@ -257,16 +252,12 @@ public final class TransactionOptions {
     }
   }
 
-  enum TransactionOptionsType {
+  public enum TransactionOptionsType {
     READ_ONLY,
     READ_WRITE
   }
 
-  interface ToProtoBuilder<ProtoBuilder> {
-    ProtoBuilder toProtoBuilder();
-  }
-
-  static final class ReadOnlyOptions implements ToProtoBuilder<ReadOnly.Builder> {
+  public static final class ReadOnlyOptions implements ToProtoBuilder<ReadOnly.Builder> {
     @Nullable private final Timestamp readTime;
 
     private ReadOnlyOptions(@Nullable Timestamp readTime) {
@@ -288,7 +279,7 @@ public final class TransactionOptions {
     }
   }
 
-  static final class ReadWriteOptions implements ToProtoBuilder<ReadWrite.Builder> {
+  public static final class ReadWriteOptions implements ToProtoBuilder<ReadWrite.Builder> {
     private final int numberOfAttempts;
 
     private ReadWriteOptions(int numberOfAttempts) {
@@ -303,5 +294,9 @@ public final class TransactionOptions {
     public int getNumberOfAttempts() {
       return numberOfAttempts;
     }
+  }
+
+  interface ToProtoBuilder<ProtoBuilder> {
+    ProtoBuilder toProtoBuilder();
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 public final class TransactionOptions {
 
   private static final TransactionOptions DEFAULT_READ_WRITE_TRANSACTION_OPTIONS =
-      readWriteOptionsBuilder().build();
+      createReadWriteOptionsBuilder().build();
 
   private static final int DEFAULT_NUM_ATTEMPTS = 5;
 
@@ -95,7 +95,7 @@ public final class TransactionOptions {
    * ReadWrite transactions and attempted up to 5 times.
    *
    * @return The TransactionOptions object.
-   * @see #readWriteOptionsBuilder()
+   * @see #createReadWriteOptionsBuilder()
    */
   @Nonnull
   public static TransactionOptions create() {
@@ -108,12 +108,12 @@ public final class TransactionOptions {
    * @param numberOfAttempts The number of execution attempts.
    * @return The TransactionOptions object.
    * @deprecated as of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setNumberOfAttempts(int)}
-   * @see #readWriteOptionsBuilder()
+   * @see #createReadWriteOptionsBuilder()
    */
   @Nonnull
   @Deprecated
   public static TransactionOptions create(int numberOfAttempts) {
-    return readWriteOptionsBuilder().setNumberOfAttempts(numberOfAttempts).build();
+    return createReadWriteOptionsBuilder().setNumberOfAttempts(numberOfAttempts).build();
   }
 
   /**
@@ -122,12 +122,12 @@ public final class TransactionOptions {
    * @param executor The executor to run the user callback code on.
    * @return The TransactionOptions object.
    * @deprecated as of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setExecutor(Executor)}
-   * @see #readWriteOptionsBuilder()
+   * @see #createReadWriteOptionsBuilder()
    */
   @Nonnull
   @Deprecated
   public static TransactionOptions create(@Nullable Executor executor) {
-    return readWriteOptionsBuilder().setExecutor(executor).build();
+    return createReadWriteOptionsBuilder().setExecutor(executor).build();
   }
 
   /**
@@ -138,24 +138,24 @@ public final class TransactionOptions {
    * @return The TransactionOptions object.
    * @deprecated as of 2.0.0, replaced by {@link ReadWriteOptionsBuilder#setExecutor(Executor)} and
    *     {@link ReadWriteOptionsBuilder#setNumberOfAttempts(int)}
-   * @see #readWriteOptionsBuilder()
+   * @see #createReadWriteOptionsBuilder()
    */
   @Nonnull
   @Deprecated
   public static TransactionOptions create(@Nullable Executor executor, int numberOfAttempts) {
-    return readWriteOptionsBuilder()
+    return createReadWriteOptionsBuilder()
         .setExecutor(executor)
         .setNumberOfAttempts(numberOfAttempts)
         .build();
   }
 
   @Nonnull
-  public static ReadWriteOptionsBuilder readWriteOptionsBuilder() {
+  public static ReadWriteOptionsBuilder createReadWriteOptionsBuilder() {
     return Builder.readWriteBuilder();
   }
 
   @Nonnull
-  public static ReadOnlyOptionsBuilder readOnlyOptionsBuilder() {
+  public static ReadOnlyOptionsBuilder createReadOnlyOptionsBuilder() {
     return Builder.readOnlyBuilder();
   }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
@@ -90,14 +90,17 @@ public final class TransactionOptions {
 
   /**
    * A {@link Timestamp} specifying the time documents are to be read at. If null, the server will
-   * read documents at the most up to date available. If nonnull, the specified {@code Timestamp}
+   * read documents at the most up to date available. If non-null, the specified {@code Timestamp}
    * may not be more than 60 seconds in the past (evaluated when the request is processed by the
    * server).
    *
-   * @return The specific time to read documents at. A null value means read most up to date data.
+   * @return The specific time to read documents at. A null value means reading the most up to date
+   *     data.
    */
   @Nullable
   public Timestamp getReadTime() {
+    // This if statement is not strictly necessary, however is kept here for clarity sake to show
+    // that readTime is only applicable to a read-only transaction type.
     if (TransactionOptionsType.READ_ONLY.equals(type)) {
       return readTime;
     } else {

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
@@ -39,7 +39,8 @@ public final class TransactionOptions {
   private final ReadOnlyOptions readOnly;
   private final ReadWriteOptions readWrite;
 
-  TransactionOptions(Executor executor,
+  TransactionOptions(
+      Executor executor,
       TransactionOptionsType type,
       ReadOnlyOptions readOnly,
       ReadWriteOptions readWrite) {
@@ -50,8 +51,7 @@ public final class TransactionOptions {
   }
 
   /**
-   * @return the initial number of attempts a read-write transaction will be
-   *     attempted
+   * @return the initial number of attempts a read-write transaction will be attempted
    * @deprecated as of v2.0.0, only applicable to Read-Write transactions. Use {@link
    *     ReadWriteOptions#getNumberOfAttempts()} instead
    */
@@ -94,7 +94,8 @@ public final class TransactionOptions {
   }
 
   /**
-   * Create a default set of options suitable for most use cases. Transactions will be opened as ReadWrite transactions and attempted up to 5 times.
+   * Create a default set of options suitable for most use cases. Transactions will be opened as
+   * ReadWrite transactions and attempted up to 5 times.
    *
    * @return The TransactionOptions object.
    * @see #readWriteOptionsBuilder()
@@ -249,7 +250,10 @@ public final class TransactionOptions {
     @Override
     public TransactionOptions build() {
       return new TransactionOptions(
-          executor, TransactionOptionsType.READ_WRITE, null, new ReadWriteOptions(numberOfAttempts));
+          executor,
+          TransactionOptionsType.READ_WRITE,
+          null,
+          new ReadWriteOptions(numberOfAttempts));
     }
   }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionOptions.java
@@ -17,16 +17,32 @@
 package com.google.cloud.firestore;
 
 import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.Preconditions;
 import com.google.firestore.v1.TransactionOptions.ReadOnly;
 import com.google.firestore.v1.TransactionOptions.ReadWrite;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.TimestampOrBuilder;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** Options specifying the behavior of Firestore Transactions. */
+/**
+ * Options specifying the behavior of Firestore Transactions.
+ *
+ * <p>A transaction in Firestore can be either read-write or read-only.
+ *
+ * <p>The default set of options is a read-write transaction with a max attempt count of 5. This
+ * attempt count can be customized via the {@link ReadWriteOptionsBuilder#setNumberOfAttempts(int)}
+ * method. A new instance of a builder can be created by calling {@link
+ * #createReadWriteOptionsBuilder()}.
+ *
+ * <p>A read-only transaction can be configured via the {@link ReadOnlyOptionsBuilder} class. A new
+ * instance can be created by calling {@link #createReadOnlyOptionsBuilder()}.
+ *
+ * @see com.google.firestore.v1.TransactionOptions
+ */
 public final class TransactionOptions {
 
   private static final TransactionOptions DEFAULT_READ_WRITE_TRANSACTION_OPTIONS =
@@ -71,11 +87,28 @@ public final class TransactionOptions {
     return executor;
   }
 
+  /**
+   * A type flag indicating the type of transaction represented. This method should be called before
+   * any call to {@link #getReadOnly()} or {@link #getReadWrite()} to determine with method to call.
+   * If a miss-matched {@code get} method is called an {@link IllegalStateException} will be thrown.
+   *
+   * @return The type of transaction this represents. Either read-only or read-write.
+   */
   @Nonnull
   public TransactionOptionsType getType() {
     return type;
   }
 
+  /**
+   * Get the set of read-only options for this instance. Before calling this method {@link
+   * #getType()} should be called, and the return value should be {@link
+   * TransactionOptionsType#READ_ONLY}.
+   *
+   * @return The instance of {@link ReadOnlyOptions} held in this instance if this instance in fact
+   *     read-only.
+   * @throws IllegalStateException if the type of this instance is {@link
+   *     TransactionOptionsType#READ_WRITE}
+   */
   @Nonnull
   public ReadOnlyOptions getReadOnly() {
     Preconditions.checkState(
@@ -83,6 +116,16 @@ public final class TransactionOptions {
     return readOnly;
   }
 
+  /**
+   * Get the set of read-write options for this instance. Before calling this method {@link
+   * #getType()} should be called, and the return value should be {@link
+   * TransactionOptionsType#READ_WRITE}.
+   *
+   * @return The instance of {@link ReadWriteOptions} held in this instance if this instance in fact
+   *     read-write.
+   * @throws IllegalStateException if the type of this instance is {@link
+   *     TransactionOptionsType#READ_ONLY}
+   */
   @Nonnull
   public ReadWriteOptions getReadWrite() {
     Preconditions.checkState(
@@ -149,16 +192,25 @@ public final class TransactionOptions {
         .build();
   }
 
+  /**
+   * @return a new builder with default values applicable to configuring options for a read-write
+   *     transaction.
+   */
   @Nonnull
   public static ReadWriteOptionsBuilder createReadWriteOptionsBuilder() {
-    return Builder.readWriteBuilder();
+    return new ReadWriteOptionsBuilder(null, DEFAULT_NUM_ATTEMPTS);
   }
 
+  /**
+   * @return a new builder with default values applicable to configuring options for a read-only
+   *     transaction.
+   */
   @Nonnull
   public static ReadOnlyOptionsBuilder createReadOnlyOptionsBuilder() {
-    return Builder.readOnlyBuilder();
+    return new ReadOnlyOptionsBuilder(null, null);
   }
 
+  @InternalExtensionOnly
   public abstract static class Builder<B extends Builder<B>> {
     @Nullable protected Executor executor;
 
@@ -166,11 +218,20 @@ public final class TransactionOptions {
       this.executor = executor;
     }
 
+    /**
+     * @return The {@link Executor} user callbacks will execute on, If null, the default executor
+     *     will be used.
+     */
     @Nullable
     public Executor getExecutor() {
       return executor;
     }
 
+    /**
+     * @param executor The {@link Executor} user callbacks will executed on. If null, the default
+     *     executor will be used.
+     * @return {@code this} builder
+     */
     @Nonnull
     @SuppressWarnings("unchecked")
     public B setExecutor(@Nullable Executor executor) {
@@ -178,18 +239,16 @@ public final class TransactionOptions {
       return (B) this;
     }
 
+    /** @return an instance of {@link TransactionOptions} from the values passed to this builder */
     @Nonnull
     public abstract TransactionOptions build();
-
-    static ReadOnlyOptionsBuilder readOnlyBuilder() {
-      return new ReadOnlyOptionsBuilder(null, null);
-    }
-
-    static ReadWriteOptionsBuilder readWriteBuilder() {
-      return new ReadWriteOptionsBuilder(null, DEFAULT_NUM_ATTEMPTS);
-    }
   }
 
+  /**
+   * A typesafe builder class representing those options that are applicable when configuring a
+   * transaction to be read-only. All methods function as "set" rather than returning a new copy
+   * with a value set on it.
+   */
   public static final class ReadOnlyOptionsBuilder extends Builder<ReadOnlyOptionsBuilder> {
     @Nullable private TimestampOrBuilder readTime;
 
@@ -198,11 +257,21 @@ public final class TransactionOptions {
       this.readTime = readTime;
     }
 
+    /** @return the currently set value that will be used as the readTime. */
     @Nullable
     public TimestampOrBuilder getReadTime() {
       return readTime;
     }
 
+    /**
+     * Specify to read documents at the given time. This may not be more than 60 in the past from
+     * when the request is processed by the server.
+     *
+     * @param readTime The specific time to read documents at. Must not be older than 60 seconds. A
+     *     null value means read most up to date data.
+     * @return {@code this} builder
+     */
+    @Nonnull
     public ReadOnlyOptionsBuilder setReadTime(@Nullable TimestampOrBuilder readTime) {
       this.readTime = readTime;
       return this;
@@ -222,6 +291,12 @@ public final class TransactionOptions {
     }
   }
 
+  /**
+   * A typesafe builder class representing those options that are applicable when configuring a
+   * transaction to be read-write. All methods function as "set" rather than returning a new copy
+   * with a value set on it. By default, a read-write transaction will be attempted a max of 5
+   * times.
+   */
   public static final class ReadWriteOptionsBuilder extends Builder<ReadWriteOptionsBuilder> {
     private int numberOfAttempts;
 
@@ -230,10 +305,24 @@ public final class TransactionOptions {
       this.numberOfAttempts = numberOfAttempts;
     }
 
+    /**
+     * Specify the max number of attempts a transaction will be attempted before resulting in an
+     * error.
+     *
+     * @return The max number of attempts to try and commit the transaction.
+     */
     public int getNumberOfAttempts() {
       return numberOfAttempts;
     }
 
+    /**
+     * Specify the max number of attempts a transaction will be attempted before resulting in an
+     * error.
+     *
+     * @param numberOfAttempts The max number of attempts to try and commit the transaction.
+     * @return {@code this} builder
+     * @throws IllegalArgumentException if numberOfAttempts is less than or equal to 0
+     */
     @Nonnull
     public ReadWriteOptionsBuilder setNumberOfAttempts(int numberOfAttempts) {
       Preconditions.checkArgument(numberOfAttempts > 0, "You must allow at least one attempt");
@@ -257,46 +346,97 @@ public final class TransactionOptions {
     READ_WRITE
   }
 
-  public static final class ReadOnlyOptions implements ToProtoBuilder<ReadOnly.Builder> {
+  /**
+   * A typesafe options class representing those options that are applicable when configuring a
+   * transaction to be read-only.
+   */
+  public static final class ReadOnlyOptions {
     @Nullable private final Timestamp readTime;
 
     private ReadOnlyOptions(@Nullable Timestamp readTime) {
       this.readTime = readTime;
     }
 
-    @Override
-    public ReadOnly.Builder toProtoBuilder() {
+    ReadOnly toProto() {
+      final ReadOnly.Builder builder = ReadOnly.getDefaultInstance().toBuilder();
       if (readTime != null) {
-        return ReadOnly.getDefaultInstance().toBuilder().setReadTime(readTime);
-      } else {
-        return ReadOnly.getDefaultInstance().toBuilder();
+        builder.setReadTime(readTime);
       }
+      return builder.build();
     }
 
+    /**
+     * Specify to read documents at the given time. This may not be more than 60 in the past from
+     * when the request is processed by the server.
+     *
+     * @return The specific time to read documents at. Must not be older than 60 seconds. A null
+     *     value means read most up to date data.
+     */
     @Nullable
     public Timestamp getReadTime() {
       return readTime;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ReadOnlyOptions that = (ReadOnlyOptions) o;
+      return Objects.equals(readTime, that.readTime);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(readTime);
+    }
   }
 
-  public static final class ReadWriteOptions implements ToProtoBuilder<ReadWrite.Builder> {
+  /**
+   * A typesafe options class representing those options that are applicable when configuring a
+   * transaction to be read-write. By default, a read-write transaction will be attempted a max of 5
+   * times.
+   */
+  public static final class ReadWriteOptions {
+    private static final ReadWrite PROTO = ReadWrite.getDefaultInstance().toBuilder().build();
     private final int numberOfAttempts;
 
     private ReadWriteOptions(int numberOfAttempts) {
       this.numberOfAttempts = numberOfAttempts;
     }
 
-    @Override
-    public ReadWrite.Builder toProtoBuilder() {
-      return ReadWrite.getDefaultInstance().toBuilder();
+    ReadWrite toProto() {
+      return PROTO;
     }
 
+    /**
+     * Specify the max number of attempts a transaction will be attempted before resulting in an
+     * error.
+     *
+     * @return The max number of attempts to try and commit the transaction.
+     */
     public int getNumberOfAttempts() {
       return numberOfAttempts;
     }
-  }
 
-  interface ToProtoBuilder<ProtoBuilder> {
-    ProtoBuilder toProtoBuilder();
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ReadWriteOptions that = (ReadWriteOptions) o;
+      return numberOfAttempts == that.numberOfAttempts;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(numberOfAttempts);
+    }
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
@@ -71,8 +71,8 @@ class TransactionRunner<T> {
   /**
    * @param firestore The active Firestore instance
    * @param userCallback The user provided transaction callback
-   * @param transactionOptions The options determining which executor the {@code userCallback}
-   *     is run on and whether the transaction is read-write or read-only
+   * @param transactionOptions The options determining which executor the {@code userCallback} is
+   *     run on and whether the transaction is read-write or read-only
    */
   TransactionRunner(
       FirestoreImpl firestore,

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
@@ -83,14 +83,7 @@ class TransactionRunner<T> {
     this.firestore = firestore;
     this.firestoreExecutor = firestore.getClient().getExecutor();
     this.userCallback = userCallback;
-    switch (transactionOptions.getType()) {
-      case READ_WRITE:
-        this.attemptsRemaining = transactionOptions.getReadWrite().getNumberOfAttempts();
-        break;
-      case READ_ONLY:
-        this.attemptsRemaining = 1;
-        break;
-    }
+    this.attemptsRemaining = transactionOptions.getNumberOfAttempts();
     this.userCallbackExecutor =
         Context.currentContextExecutor(
             transactionOptions.getExecutor() != null

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
@@ -26,7 +26,6 @@ import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.retrying.ExponentialRetryAlgorithm;
 import com.google.api.gax.retrying.TimedAttemptSettings;
 import com.google.api.gax.rpc.ApiException;
-import com.google.cloud.firestore.TransactionOptions.EitherReadOnlyOrReadWrite;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Context;
@@ -84,10 +83,9 @@ class TransactionRunner<T> {
     this.firestore = firestore;
     this.firestoreExecutor = firestore.getClient().getExecutor();
     this.userCallback = userCallback;
-    final EitherReadOnlyOrReadWrite options = transactionOptions.getOptions();
-    switch (options.getType()) {
+    switch (transactionOptions.getType()) {
       case READ_WRITE:
-        this.attemptsRemaining = options.getReadWrite().getNumberOfAttempts();
+        this.attemptsRemaining = transactionOptions.getReadWrite().getNumberOfAttempts();
         break;
       case READ_ONLY:
         this.attemptsRemaining = 1;

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
@@ -72,8 +72,8 @@ class TransactionRunner<T> {
   /**
    * @param firestore The active Firestore instance
    * @param userCallback The user provided transaction callback
-   * @param transactionOptions The set options determining which executor the {@code userCallback}
-   *     is run on, whether the transaction is read-write or read-only
+   * @param transactionOptions The options determining which executor the {@code userCallback}
+   *     is run on and whether the transaction is read-write or read-only
    */
   TransactionRunner(
       FirestoreImpl firestore,

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
@@ -895,7 +895,7 @@ public class TransactionTest {
     assertThat(transactionOptions.getExecutor()).isSameInstanceAs(executor);
 
     assertThat(transactionOptions.getType()).isEqualTo(TransactionOptionsType.READ_ONLY);
-    final ReadOnlyOptions readOnly = options.getReadOnly();
+    final ReadOnlyOptions readOnly = transactionOptions.getReadOnly();
     // actually build the builder so we get a useful .equals method
     assertThat(readOnly.toProtoBuilder().build()).isEqualTo(expectedReadOnly);
   }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
@@ -884,7 +884,9 @@ public class TransactionTest {
     final com.google.protobuf.Timestamp.Builder readTime =
         com.google.protobuf.Timestamp.getDefaultInstance().toBuilder().setSeconds(1).setNanos(0);
     final ReadOnlyOptionsBuilder builder =
-        TransactionOptions.createReadOnlyOptionsBuilder().setExecutor(executor).setReadTime(readTime);
+        TransactionOptions.createReadOnlyOptionsBuilder()
+            .setExecutor(executor)
+            .setReadTime(readTime);
     final ReadOnly expectedReadOnly = ReadOnly.newBuilder().setReadTime(readTime).build();
 
     final TransactionOptions transactionOptions = builder.build();
@@ -896,8 +898,7 @@ public class TransactionTest {
 
     assertThat(transactionOptions.getType()).isEqualTo(TransactionOptionsType.READ_ONLY);
     final ReadOnlyOptions readOnly = transactionOptions.getReadOnly();
-    // actually build the builder so we get a useful .equals method
-    assertThat(readOnly.toProtoBuilder().build()).isEqualTo(expectedReadOnly);
+    assertThat(readOnly.toProto()).isEqualTo(expectedReadOnly);
   }
 
   @Test
@@ -912,8 +913,7 @@ public class TransactionTest {
 
     final ReadOnlyOptions readOnly = transactionOptions.getReadOnly();
     assertThat(readOnly.getReadTime()).isNull();
-    // actually build the builder so we get a useful .equals method
-    assertThat(readOnly.toProtoBuilder().build()).isEqualTo(expectedReadOnly);
+    assertThat(readOnly.toProto()).isEqualTo(expectedReadOnly);
   }
 
   @Test
@@ -932,7 +932,9 @@ public class TransactionTest {
   public void readWriteTransactionOptionsBuilder_setNumberOfAttempts() {
     Executor executor = mock(Executor.class);
     final ReadWriteOptionsBuilder builder =
-        TransactionOptions.createReadWriteOptionsBuilder().setExecutor(executor).setNumberOfAttempts(2);
+        TransactionOptions.createReadWriteOptionsBuilder()
+            .setExecutor(executor)
+            .setNumberOfAttempts(2);
     final ReadWrite expectedReadWrite = ReadWrite.newBuilder().build();
 
     final TransactionOptions transactionOptions = builder.build();
@@ -944,8 +946,7 @@ public class TransactionTest {
 
     assertThat(transactionOptions.getType()).isEqualTo(TransactionOptionsType.READ_WRITE);
     final ReadWriteOptions readWrite = options.getReadWrite();
-    // actually build the builder so we get a useful .equals method
-    assertThat(readWrite.toProtoBuilder().build()).isEqualTo(expectedReadWrite);
+    assertThat(readWrite.toProto()).isEqualTo(expectedReadWrite);
   }
 
   @Test
@@ -959,8 +960,7 @@ public class TransactionTest {
     assertThat(transactionOptions.getExecutor()).isNull();
     assertThat(readWrite.getNumberOfAttempts()).isEqualTo(5);
 
-    // actually build the builder so we get a useful .equals method
-    assertThat(readWrite.toProtoBuilder().build()).isEqualTo(expectedReadWrite);
+    assertThat(readWrite.toProto()).isEqualTo(expectedReadWrite);
   }
 
   @Test

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
@@ -884,7 +884,7 @@ public class TransactionTest {
     final com.google.protobuf.Timestamp.Builder readTime =
         com.google.protobuf.Timestamp.getDefaultInstance().toBuilder().setSeconds(1).setNanos(0);
     final ReadOnlyOptionsBuilder builder =
-        TransactionOptions.readOnlyOptionsBuilder().setExecutor(executor).setReadTime(readTime);
+        TransactionOptions.createReadOnlyOptionsBuilder().setExecutor(executor).setReadTime(readTime);
     final ReadOnly expectedReadOnly = ReadOnly.newBuilder().setReadTime(readTime).build();
 
     final TransactionOptions transactionOptions = builder.build();
@@ -902,7 +902,7 @@ public class TransactionTest {
 
   @Test
   public void readOnlyTransactionOptionsBuilder_defaults() {
-    final ReadOnlyOptionsBuilder builder = TransactionOptions.readOnlyOptionsBuilder();
+    final ReadOnlyOptionsBuilder builder = TransactionOptions.createReadOnlyOptionsBuilder();
     final ReadOnly expectedReadOnly = ReadOnly.newBuilder().build();
 
     final TransactionOptions transactionOptions = builder.build();
@@ -918,7 +918,7 @@ public class TransactionTest {
 
   @Test
   public void readOnlyTransactionOptionsBuilder_errorWhenGettingReadWrite() {
-    final ReadOnlyOptionsBuilder builder = TransactionOptions.readOnlyOptionsBuilder();
+    final ReadOnlyOptionsBuilder builder = TransactionOptions.createReadOnlyOptionsBuilder();
     try {
       //noinspection ResultOfMethodCallIgnored
       builder.build().getReadWrite();
@@ -932,7 +932,7 @@ public class TransactionTest {
   public void readWriteTransactionOptionsBuilder_setNumberOfAttempts() {
     Executor executor = mock(Executor.class);
     final ReadWriteOptionsBuilder builder =
-        TransactionOptions.readWriteOptionsBuilder().setExecutor(executor).setNumberOfAttempts(2);
+        TransactionOptions.createReadWriteOptionsBuilder().setExecutor(executor).setNumberOfAttempts(2);
     final ReadWrite expectedReadWrite = ReadWrite.newBuilder().build();
 
     final TransactionOptions transactionOptions = builder.build();
@@ -953,7 +953,7 @@ public class TransactionTest {
     final ReadWrite expectedReadWrite = ReadWrite.newBuilder().build();
 
     final TransactionOptions transactionOptions =
-        TransactionOptions.readWriteOptionsBuilder().build();
+        TransactionOptions.createReadWriteOptionsBuilder().build();
     final ReadWriteOptions readWrite = transactionOptions.getReadWrite();
 
     assertThat(transactionOptions.getExecutor()).isNull();
@@ -965,7 +965,7 @@ public class TransactionTest {
 
   @Test
   public void readWriteTransactionOptionsBuilder_errorWhenGettingReadWrite() {
-    final ReadWriteOptionsBuilder builder = TransactionOptions.readWriteOptionsBuilder();
+    final ReadWriteOptionsBuilder builder = TransactionOptions.createReadWriteOptionsBuilder();
     try {
       //noinspection ResultOfMethodCallIgnored
       builder.build().getReadOnly();
@@ -978,7 +978,7 @@ public class TransactionTest {
   @Test
   public void readWriteTransactionOptionsBuilder_errorAttemptingToSetNumAttemptsLessThanOne() {
     try {
-      TransactionOptions.readWriteOptionsBuilder().setNumberOfAttempts(0);
+      TransactionOptions.createReadWriteOptionsBuilder().setNumberOfAttempts(0);
       fail("Error expected");
     } catch (IllegalArgumentException ignore) {
       // expected

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
@@ -53,7 +53,6 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.LocalFirestoreHelper.ResponseStubber;
-import com.google.cloud.firestore.TransactionOptions.EitherReadOnlyOrReadWrite;
 import com.google.cloud.firestore.TransactionOptions.ReadOnlyOptions;
 import com.google.cloud.firestore.TransactionOptions.ReadOnlyOptionsBuilder;
 import com.google.cloud.firestore.TransactionOptions.ReadWriteOptions;
@@ -71,6 +70,7 @@ import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -87,6 +87,7 @@ import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Stubber;
 
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
@@ -892,9 +893,8 @@ public class TransactionTest {
     assertThat(builder.getReadTime()).isSameInstanceAs(readTime);
 
     assertThat(transactionOptions.getExecutor()).isSameInstanceAs(executor);
-    final EitherReadOnlyOrReadWrite options = transactionOptions.getOptions();
 
-    assertThat(options.getType()).isEqualTo(TransactionOptionsType.READ_ONLY);
+    assertThat(transactionOptions.getType()).isEqualTo(TransactionOptionsType.READ_ONLY);
     final ReadOnlyOptions readOnly = options.getReadOnly();
     // actually build the builder so we get a useful .equals method
     assertThat(readOnly.toProtoBuilder().build()).isEqualTo(expectedReadOnly);
@@ -910,7 +910,7 @@ public class TransactionTest {
     assertThat(builder.getExecutor()).isNull();
     assertThat(builder.getReadTime()).isNull();
 
-    final ReadOnlyOptions readOnly = transactionOptions.getOptions().getReadOnly();
+    final ReadOnlyOptions readOnly = transactionOptions.getReadOnly();
     assertThat(readOnly.getReadTime()).isNull();
     // actually build the builder so we get a useful .equals method
     assertThat(readOnly.toProtoBuilder().build()).isEqualTo(expectedReadOnly);
@@ -921,7 +921,7 @@ public class TransactionTest {
     final ReadOnlyOptionsBuilder builder = TransactionOptions.readOnlyOptionsBuilder();
     try {
       //noinspection ResultOfMethodCallIgnored
-      builder.build().getOptions().getReadWrite();
+      builder.build().getReadWrite();
       fail("Error expected");
     } catch (IllegalStateException ignore) {
       // expected
@@ -941,9 +941,8 @@ public class TransactionTest {
     assertThat(builder.getNumberOfAttempts()).isEqualTo(2);
 
     assertThat(transactionOptions.getExecutor()).isSameInstanceAs(executor);
-    final EitherReadOnlyOrReadWrite options = transactionOptions.getOptions();
 
-    assertThat(options.getType()).isEqualTo(TransactionOptionsType.READ_WRITE);
+    assertThat(transactionOptions.getType()).isEqualTo(TransactionOptionsType.READ_WRITE);
     final ReadWriteOptions readWrite = options.getReadWrite();
     // actually build the builder so we get a useful .equals method
     assertThat(readWrite.toProtoBuilder().build()).isEqualTo(expectedReadWrite);
@@ -955,7 +954,7 @@ public class TransactionTest {
 
     final TransactionOptions transactionOptions =
         TransactionOptions.readWriteOptionsBuilder().build();
-    final ReadWriteOptions readWrite = transactionOptions.getOptions().getReadWrite();
+    final ReadWriteOptions readWrite = transactionOptions.getReadWrite();
 
     assertThat(transactionOptions.getExecutor()).isNull();
     assertThat(readWrite.getNumberOfAttempts()).isEqualTo(5);
@@ -969,7 +968,7 @@ public class TransactionTest {
     final ReadWriteOptionsBuilder builder = TransactionOptions.readWriteOptionsBuilder();
     try {
       //noinspection ResultOfMethodCallIgnored
-      builder.build().getOptions().getReadOnly();
+      builder.build().getReadOnly();
       fail("Error expected");
     } catch (IllegalStateException ignore) {
       // expected

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
@@ -70,7 +70,6 @@ import io.grpc.Status;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -87,7 +86,6 @@ import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Stubber;
 
 @SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -1441,7 +1441,7 @@ public class ITSystemTest {
                 return null;
               }
             },
-            TransactionOptions.readOnlyOptionsBuilder().build());
+            TransactionOptions.createReadOnlyOptionsBuilder().build());
 
     runTransaction.get(10, TimeUnit.SECONDS);
     assertEquals("bar", ref.get().get("foo"));
@@ -1461,7 +1461,7 @@ public class ITSystemTest {
                 return null;
               }
             },
-            TransactionOptions.readOnlyOptionsBuilder().build());
+            TransactionOptions.createReadOnlyOptionsBuilder().build());
 
     try {
       runTransaction.get(10, TimeUnit.SECONDS);
@@ -1483,7 +1483,7 @@ public class ITSystemTest {
     final DocumentReference documentReference = randomColl.add(SINGLE_FIELD_MAP).get();
 
     final TransactionOptions options =
-        TransactionOptions.readOnlyOptionsBuilder()
+        TransactionOptions.createReadOnlyOptionsBuilder()
             .setReadTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(1).setNanos(0))
             .build();
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -1448,7 +1448,7 @@ public class ITSystemTest {
   }
 
   @Test
-  public void readOnlyTransaction_faliureWhenAttemptingWrite()
+  public void readOnlyTransaction_failureWhenAttemptingWrite()
       throws InterruptedException, TimeoutException {
 
     final DocumentReference documentReference = randomColl.document("tx/ro/writeShouldFail");

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.firestore.it;
 
 import static com.google.cloud.firestore.LocalFirestoreHelper.UPDATE_SINGLE_FIELD_OBJECT;
 import static com.google.cloud.firestore.LocalFirestoreHelper.map;
+import static com.google.common.truth.Truth.assertThat;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -56,12 +57,16 @@ import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.SetOptions;
 import com.google.cloud.firestore.Transaction;
 import com.google.cloud.firestore.Transaction.Function;
+import com.google.cloud.firestore.TransactionOptions;
 import com.google.cloud.firestore.WriteBatch;
 import com.google.cloud.firestore.WriteResult;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firestore.v1.RunQueryRequest;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,8 +77,12 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1412,6 +1421,93 @@ public class ITSystemTest {
 
     ApiFuture<DocumentSnapshot> result = docRef.get();
     assertEquals(Collections.singletonMap("foo", "bar3"), result.get().getData());
+  }
+
+  @Test
+  public void readOnlyTransaction_successfulGet()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    final DocumentReference documentReference = randomColl.add(SINGLE_FIELD_MAP).get();
+
+    final AtomicReference<DocumentSnapshot> ref = new AtomicReference<>();
+
+    final ApiFuture<Void> runTransaction =
+        firestore.runTransaction(
+            new Function<Void>() {
+              @Override
+              public Void updateCallback(Transaction transaction) throws Exception {
+                final DocumentSnapshot snapshot =
+                    transaction.get(documentReference).get(5, TimeUnit.SECONDS);
+                ref.compareAndSet(null, snapshot);
+                return null;
+              }
+            },
+            TransactionOptions.readOnlyOptionsBuilder().build());
+
+    runTransaction.get(10, TimeUnit.SECONDS);
+    assertEquals("bar", ref.get().get("foo"));
+  }
+
+  @Test
+  public void readOnlyTransaction_faliureWhenAttemptingWrite()
+      throws InterruptedException, TimeoutException {
+
+    final DocumentReference documentReference = randomColl.document("tx/ro/writeShouldFail");
+    final ApiFuture<Void> runTransaction =
+        firestore.runTransaction(
+            new Function<Void>() {
+              @Override
+              public Void updateCallback(Transaction transaction) {
+                transaction.set(documentReference, SINGLE_FIELD_MAP);
+                return null;
+              }
+            },
+            TransactionOptions.readOnlyOptionsBuilder().build());
+
+    try {
+      runTransaction.get(10, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
+      final Throwable cause = e.getCause();
+      assertThat(cause).isInstanceOf(FirestoreException.class);
+      final Throwable rootCause = ExceptionUtils.getRootCause(cause);
+      assertThat(rootCause).isInstanceOf(StatusRuntimeException.class);
+      final StatusRuntimeException invalidArgument = (StatusRuntimeException) rootCause;
+      final Status status = invalidArgument.getStatus();
+      assertThat(status.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+      assertThat(status.getDescription()).contains("read-only");
+    }
+  }
+
+  @Test
+  public void readOnlyTransaction_failureWhenAttemptReadOlderThan60Seconds()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    final DocumentReference documentReference = randomColl.add(SINGLE_FIELD_MAP).get();
+
+    final TransactionOptions options =
+        TransactionOptions.readOnlyOptionsBuilder()
+            .setReadTime(com.google.protobuf.Timestamp.newBuilder().setSeconds(1).setNanos(0))
+            .build();
+
+    final ApiFuture<Void> runTransaction =
+        firestore.runTransaction(
+            new Function<Void>() {
+              @Override
+              public Void updateCallback(Transaction transaction) throws Exception {
+                transaction.get(documentReference).get(5, TimeUnit.SECONDS);
+                return null;
+              }
+            },
+            options);
+
+    try {
+      runTransaction.get(10, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
+      final Throwable rootCause = ExceptionUtils.getRootCause(e);
+      assertThat(rootCause).isInstanceOf(StatusRuntimeException.class);
+      final StatusRuntimeException invalidArgument = (StatusRuntimeException) rootCause;
+      final Status status = invalidArgument.getStatus();
+      assertThat(status.getCode()).isEqualTo(Code.FAILED_PRECONDITION);
+      assertThat(status.getDescription()).contains("old");
+    }
   }
 
   /** Wrapper around ApiStreamObserver that returns the results in a list. */


### PR DESCRIPTION
* Add new typesafe builders for read-only `TransactionOptions.readOnlyOptionsBuilder` and read-write `TransactionOptions.readWriteOptionsBuilder` transactions in TransactionOptions
  * These new builders ensure only those parameters relevant to the respective type of transaction are available
* Deprecate existing `TransactionOptions.create(...)` methods in favor of the new builders
* Deprecate existing and annotate @InternalApi `TransactionOptions.getNumberOfAttempts`
* Update Transaction and TransactionRunner to use TransactionOptions directly

