### PR TITLE
fix: refactor FakeCredentials

### DIFF
--- a/google-cloud-firestore/clirr-ignored-differences.xml
+++ b/google-cloud-firestore/clirr-ignored-differences.xml
@@ -157,4 +157,14 @@
     <to>com.google.cloud.firestore.CollectionGroup</to>
   </difference>
 
+  <!--
+  FakeCredentials Refactor
+  com.google.cloud.firestore.FirestoreOptions$Builder$FakeCredentials -> com.google.cloud.firestore.FirestoreOptions$EmulatorCredentials
+  -->
+  <difference>
+    <differenceType>8001</differenceType>
+    <className>com/google/cloud/firestore/FirestoreOptions$Builder$FakeCredentials</className>
+    <to>*</to>
+  </difference>
+
 </differences>

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreOptions.java
@@ -231,39 +231,39 @@ public final class FirestoreOptions extends ServiceOptions<Firestore, FirestoreO
                 .build());
         // Use a `CredentialProvider` to match the Firebase Admin SDK, which prevents the Admin SDK
         // from overwriting the Emulator credentials.
-        this.setCredentialsProvider(FixedCredentialsProvider.create(new FakeCredentials()));
+        this.setCredentialsProvider(FixedCredentialsProvider.create(new EmulatorCredentials()));
       }
 
       return new FirestoreOptions(this);
     }
+  }
 
-    public class FakeCredentials extends Credentials {
-      private final Map<String, List<String>> HEADERS =
-          ImmutableMap.of("Authorization", Arrays.asList("Bearer owner"));
+  public static class EmulatorCredentials extends Credentials {
+    private final Map<String, List<String>> HEADERS =
+        ImmutableMap.of("Authorization", Arrays.asList("Bearer owner"));
 
-      @Override
-      public String getAuthenticationType() {
-        throw new IllegalArgumentException("Not supported");
-      }
-
-      @Override
-      public Map<String, List<String>> getRequestMetadata(URI uri) {
-        return HEADERS;
-      }
-
-      @Override
-      public boolean hasRequestMetadata() {
-        return true;
-      }
-
-      @Override
-      public boolean hasRequestMetadataOnly() {
-        return true;
-      }
-
-      @Override
-      public void refresh() {}
+    @Override
+    public String getAuthenticationType() {
+      throw new IllegalArgumentException("Not supported");
     }
+
+    @Override
+    public Map<String, List<String>> getRequestMetadata(URI uri) {
+      return HEADERS;
+    }
+
+    @Override
+    public boolean hasRequestMetadata() {
+      return true;
+    }
+
+    @Override
+    public boolean hasRequestMetadataOnly() {
+      return true;
+    }
+
+    @Override
+    public void refresh() {}
   }
 
   @InternalApi("This class should only be extended within google-cloud-java")


### PR DESCRIPTION
This change allows users who want to try to manually configured FirestoreOptions for an emulator to be able to leverage the credentials we use when boostrapping via environment variable.

* Rename FakeCredentials to EmulatorCredentials
* Make EmulatorCredentials static
* Move from inner class of FirestoreOptions.Builder to inner class of FirestoreOptions

Related to #190

