### PR TITLE
chore(build): cleanup manually set api-commons version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,13 +177,6 @@
         <version>1.35.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-firestore-v1:current} -->
       </dependency>
 
-      <!-- Remove after google-cloud-shared-dependencies is up to v0.8.4 -->
-      <dependency>
-        <groupId>com.google.api</groupId>
-        <artifactId>api-common</artifactId>
-        <version>1.10.0</version>
-      </dependency>
-
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>


### PR DESCRIPTION
Now that shared-dependencies v0.8.6 has been released and is used in pom.xml we no longer need the manual version pull for api-commons.