### PR TITLE
chore: fix URLs found in POM files changed to match typical repository URL format

### DIFF
--- a/google-cloud-firestore-admin/pom.xml
+++ b/google-cloud-firestore-admin/pom.xml
@@ -7,8 +7,7 @@
   <version>2.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore-admin:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Firestore Admin Client</name>
-  <url>https://github.com/googleapis/java-firestore/tree/master
-  </url>
+  <url>https://github.com/googleapis/java-firestore</url>
   <description>
     Java idiomatic client for Google Cloud Firestore Admin API.
   </description>

--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -7,8 +7,7 @@
   <version>2.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Firestore</name>
-  <url>https://github.com/googleapis/java-firestore/tree/master
-  </url>
+  <url>https://github.com/googleapis/java-firestore</url>
   <description>
     Java idiomatic client for Google Cloud Firestore.
   </description>


### PR DESCRIPTION
Removed /master/tree from POM file links to match style of other Google Cloud libraries