### PR TITLE
feat: add max/min throttling options to BulkWriterOptions

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
 
 final class BulkWriter implements AutoCloseable {
   /** The maximum number of writes that can be in a single batch. */
-  public static final int MAX_BATCH_SIZE = 20;
+  public static final int MAX_BATCH_SIZE = 25;
 
   public static final int MAX_RETRY_ATTEMPTS = 10;
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
 
 final class BulkWriter implements AutoCloseable {
   /** The maximum number of writes that can be in a single batch. */
-  public static final int MAX_BATCH_SIZE = 500;
+  public static final int MAX_BATCH_SIZE = 20;
 
   public static final int MAX_RETRY_ATTEMPTS = 10;
 
@@ -129,6 +129,13 @@ final class BulkWriter implements AutoCloseable {
       if (maxRate < startingRate) {
         startingRate = maxRate;
       }
+
+      // Ensure that the batch size is not larger than the number of allowed
+      // operations per second.
+      if (startingRate < maxBatchSize) {
+        this.maxBatchSize = (int) startingRate;
+      }
+
       this.rateLimiter =
           new RateLimiter(
               (int) startingRate,

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
 
 final class BulkWriter implements AutoCloseable {
   /** The maximum number of writes that can be in a single batch. */
-  public static final int MAX_BATCH_SIZE = 25;
+  public static final int MAX_BATCH_SIZE = 500;
 
   public static final int MAX_RETRY_ATTEMPTS = 10;
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
@@ -53,7 +53,7 @@ final class BulkWriter implements AutoCloseable {
    * @see <a href=https://cloud.google.com/datastore/docs/best-practices#ramping_up_traffic>Ramping
    *     up traffic</a>
    */
-  private static final int STARTING_MAXIMUM_OPS_PER_SECOND = 500;
+  static final int DEFAULT_STARTING_MAXIMUM_OPS_PER_SECOND = 500;
 
   /**
    * The rate by which to increase the capacity as specified by the 500/50/5 rule.
@@ -97,7 +97,8 @@ final class BulkWriter implements AutoCloseable {
   private final ExponentialRetryAlgorithm backoff;
   private TimedAttemptSettings nextAttempt;
 
-  BulkWriter(FirestoreImpl firestore, boolean enableThrottling) {
+  BulkWriter(FirestoreImpl firestore, BulkWriterOptions options) {
+    validateBulkWriterOptions(options);
     this.firestore = firestore;
     this.backoff =
         new ExponentialRetryAlgorithm(
@@ -105,14 +106,35 @@ final class BulkWriter implements AutoCloseable {
     this.nextAttempt = backoff.createFirstAttempt();
     this.firestoreExecutor = firestore.getClient().getExecutor();
 
-    if (enableThrottling) {
-      rateLimiter =
+    if (!options.isThrottlingEnabled()) {
+      this.rateLimiter =
           new RateLimiter(
-              STARTING_MAXIMUM_OPS_PER_SECOND,
-              RATE_LIMITER_MULTIPLIER,
-              RATE_LIMITER_MULTIPLIER_MILLIS);
+              Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
     } else {
-      rateLimiter = new RateLimiter(Integer.MAX_VALUE, Double.MAX_VALUE, Integer.MAX_VALUE);
+      double startingRate = DEFAULT_STARTING_MAXIMUM_OPS_PER_SECOND;
+      double maxRate = Integer.MAX_VALUE;
+
+      if (options.getInitialOpsPerSecond() != BulkWriterOptions.DEFAULT_UNSET_VALUE) {
+        startingRate = options.getInitialOpsPerSecond();
+      }
+
+      if (options.getMaxOpsPerSecond() != BulkWriterOptions.DEFAULT_UNSET_VALUE) {
+        maxRate = options.getMaxOpsPerSecond();
+      }
+
+      // The initial validation step ensures that the maxOpsPerSecond is
+      // greater than initialOpsPerSecond. If this inequality is true, that
+      // means initialOpsPerSecond was not set and maxOpsPerSecond is less
+      // than the default starting rate.
+      if (maxRate < startingRate) {
+        startingRate = maxRate;
+      }
+      this.rateLimiter =
+          new RateLimiter(
+              (int) startingRate,
+              RATE_LIMITER_MULTIPLIER,
+              RATE_LIMITER_MULTIPLIER_MILLIS,
+              (int) maxRate);
     }
   }
 
@@ -678,5 +700,34 @@ final class BulkWriter implements AutoCloseable {
   @VisibleForTesting
   void setMaxBatchSize(int size) {
     maxBatchSize = size;
+  }
+
+  @VisibleForTesting
+  RateLimiter getRateLimiter() {
+    return rateLimiter;
+  }
+
+  private void validateBulkWriterOptions(BulkWriterOptions options) {
+    double initialRate = options.getInitialOpsPerSecond();
+    double maxRate = options.getMaxOpsPerSecond();
+
+    if (initialRate < 1) {
+      throw FirestoreException.invalidState(
+          "Value for argument 'initialOpsPerSecond' must be an integer within [1, Infinity], but was: "
+              + (int) initialRate);
+    }
+
+    if (maxRate < 1) {
+      throw FirestoreException.invalidState(
+          "Value for argument 'maxOpsPerSecond' must be an integer within [1, Infinity], but was: "
+              + (int) maxRate);
+    }
+
+    if (initialRate != BulkWriterOptions.DEFAULT_UNSET_VALUE
+        && maxRate != BulkWriterOptions.DEFAULT_UNSET_VALUE
+        && initialRate > maxRate) {
+      throw FirestoreException.invalidState(
+          "'maxOpsPerSecond' cannot be less than 'initialOpsPerSecond'.");
+    }
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriterOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriterOptions.java
@@ -16,88 +16,70 @@
 
 package com.google.cloud.firestore;
 
-import javax.annotation.Nonnull;
+import com.google.auto.value.AutoValue;
 
-/** Options used to disable request throttling in BulkWriter. */
-final class BulkWriterOptions {
-  static final double DEFAULT_UNSET_VALUE = 1.1;
-  private final boolean throttling;
-  private double initialOpsPerSecond = DEFAULT_UNSET_VALUE;
-  private double maxOpsPerSecond = DEFAULT_UNSET_VALUE;
-
-  BulkWriterOptions(boolean enableThrottling) {
-    this.throttling = enableThrottling;
-  }
-
-  private BulkWriterOptions(double initialOpsPerSecond, double maxOpsPerSecond) {
-    this.throttling = true;
-    this.initialOpsPerSecond = initialOpsPerSecond;
-    this.maxOpsPerSecond = maxOpsPerSecond;
-  }
-
-  boolean isThrottlingEnabled() {
-    return throttling;
-  }
-
-  double getInitialOpsPerSecond() {
-    return initialOpsPerSecond;
-  }
-
-  double getMaxOpsPerSecond() {
-    return maxOpsPerSecond;
-  }
+/** Options used to configure request throttling in BulkWriter. */
+@AutoValue
+abstract class BulkWriterOptions {
+  /**
+   * Return whether throttling is enabled.
+   *
+   * @return Whether throttling is enabled.
+   */
+  abstract boolean getThrottlingEnabled();
 
   /**
-   * An options object that will disable throttling in the created BulkWriter.
+   * Returns the initial maximum number of operations per second allowed by the throttler.
    *
-   * @return The BulkWriterOptions object.
+   * @return The initial maximum number of operations per second allowed by the throttler.
    */
-  @Nonnull
-  public static BulkWriterOptions withThrottlingDisabled() {
-    return new BulkWriterOptions(false);
-  }
+  abstract double getInitialOpsPerSecond();
 
   /**
-   * An options object that will enable throttling in the created BulkWriter with the provided
-   * starting rate.
+   * Returns the maximum number of operations per second allowed by the throttler.
    *
-   * @param initialOpsPerSecond The initial maximum number of operations per second allowed by the
-   *     throttler.
-   * @return The BulkWriterOptions object.
+   * <p>The throttler's allowed operations per second does not ramp up past the specified operations
+   * per second.
+   *
+   * @return The maximum number of operations per second allowed by the throttler.
    */
-  @Nonnull
-  public static BulkWriterOptions withInitialOpsPerSecondThrottling(int initialOpsPerSecond) {
-    return new BulkWriterOptions(initialOpsPerSecond, DEFAULT_UNSET_VALUE);
+  abstract double getMaxOpsPerSecond();
+
+  static Builder builder() {
+    return new AutoValue_BulkWriterOptions.Builder()
+        .setMaxOpsPerSecond(Double.NaN)
+        .setInitialOpsPerSecond(Double.NaN)
+        .setThrottlingEnabled(true);
   }
 
-  /**
-   * An options object that will enable throttling in the created BulkWriter with the provided
-   * maximum rate.
-   *
-   * @param maxOpsPerSecond The maximum number of operations per second allowed by the throttler.
-   *     The throttler's allowed operations per second does not ramp up past the specified
-   *     operations per second.
-   * @return The BulkWriterOptions object.
-   */
-  @Nonnull
-  public static BulkWriterOptions withMaxOpsPerSecondThrottling(int maxOpsPerSecond) {
-    return new BulkWriterOptions(DEFAULT_UNSET_VALUE, maxOpsPerSecond);
-  }
+  abstract Builder toBuilder();
 
-  /**
-   * An options object that will enable throttling in the created BulkWriter with the provided
-   * starting and maximum rate.
-   *
-   * @param initialOpsPerSecond The initial maximum number of operations per second allowed by the
-   *     throttler.
-   * @param maxOpsPerSecond The maximum number of operations per second allowed by the throttler.
-   *     The throttler's allowed operations per second does not ramp up past the specified
-   *     operations per second.
-   * @return The BulkWriterOptions object.
-   */
-  @Nonnull
-  public static BulkWriterOptions withCustomThrottling(
-      int initialOpsPerSecond, int maxOpsPerSecond) {
-    return new BulkWriterOptions(initialOpsPerSecond, maxOpsPerSecond);
+  @AutoValue.Builder
+  abstract static class Builder {
+    /**
+     * Sets whether throttling should be enabled. By default, throttling is enabled.
+     *
+     * @param enabled Whether throttling should be enabled.
+     */
+    abstract Builder setThrottlingEnabled(boolean enabled);
+
+    /**
+     * Set the initial maximum number of operations per second allowed by the throttler.
+     *
+     * @param initialOpsPerSecond The initial maximum number of operations per second allowed by the
+     *     throttler.
+     */
+    abstract Builder setInitialOpsPerSecond(double initialOpsPerSecond);
+
+    /**
+     * Set the maximum number of operations per second allowed by the throttler.
+     *
+     * @param maxOpsPerSecond The maximum number of operations per second allowed by the throttler.
+     *     The throttler's allowed operations per second does not ramp up past the specified
+     *     operations per second.
+     */
+    abstract Builder setMaxOpsPerSecond(double maxOpsPerSecond);
+
+    abstract BulkWriterOptions build();
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriterOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriterOptions.java
@@ -20,15 +20,31 @@ import javax.annotation.Nonnull;
 
 /** Options used to disable request throttling in BulkWriter. */
 final class BulkWriterOptions {
+  static final double DEFAULT_UNSET_VALUE = 1.1;
+  private final boolean throttling;
+  private double initialOpsPerSecond = DEFAULT_UNSET_VALUE;
+  private double maxOpsPerSecond = DEFAULT_UNSET_VALUE;
 
-  private final boolean enableThrottling;
+  BulkWriterOptions(boolean enableThrottling) {
+    this.throttling = enableThrottling;
+  }
 
-  private BulkWriterOptions(boolean enableThrottling) {
-    this.enableThrottling = enableThrottling;
+  private BulkWriterOptions(double initialOpsPerSecond, double maxOpsPerSecond) {
+    this.throttling = true;
+    this.initialOpsPerSecond = initialOpsPerSecond;
+    this.maxOpsPerSecond = maxOpsPerSecond;
   }
 
   boolean isThrottlingEnabled() {
-    return enableThrottling;
+    return throttling;
+  }
+
+  double getInitialOpsPerSecond() {
+    return initialOpsPerSecond;
+  }
+
+  double getMaxOpsPerSecond() {
+    return maxOpsPerSecond;
   }
 
   /**
@@ -39,5 +55,49 @@ final class BulkWriterOptions {
   @Nonnull
   public static BulkWriterOptions withThrottlingDisabled() {
     return new BulkWriterOptions(false);
+  }
+
+  /**
+   * An options object that will enable throttling in the created BulkWriter with the provided
+   * starting rate.
+   *
+   * @param initialOpsPerSecond The initial maximum number of operations per second allowed by the
+   *     throttler.
+   * @return The BulkWriterOptions object.
+   */
+  @Nonnull
+  public static BulkWriterOptions withInitialOpsPerSecondThrottling(int initialOpsPerSecond) {
+    return new BulkWriterOptions(initialOpsPerSecond, DEFAULT_UNSET_VALUE);
+  }
+
+  /**
+   * An options object that will enable throttling in the created BulkWriter with the provided
+   * maximum rate.
+   *
+   * @param maxOpsPerSecond The maximum number of operations per second allowed by the throttler.
+   *     The throttler's allowed operations per second does not ramp up past the specified
+   *     operations per second.
+   * @return The BulkWriterOptions object.
+   */
+  @Nonnull
+  public static BulkWriterOptions withMaxOpsPerSecondThrottling(int maxOpsPerSecond) {
+    return new BulkWriterOptions(DEFAULT_UNSET_VALUE, maxOpsPerSecond);
+  }
+
+  /**
+   * An options object that will enable throttling in the created BulkWriter with the provided
+   * starting and maximum rate.
+   *
+   * @param initialOpsPerSecond The initial maximum number of operations per second allowed by the
+   *     throttler.
+   * @param maxOpsPerSecond The maximum number of operations per second allowed by the throttler.
+   *     The throttler's allowed operations per second does not ramp up past the specified
+   *     operations per second.
+   * @return The BulkWriterOptions object.
+   */
+  @Nonnull
+  public static BulkWriterOptions withCustomThrottling(
+      int initialOpsPerSecond, int maxOpsPerSecond) {
+    return new BulkWriterOptions(initialOpsPerSecond, maxOpsPerSecond);
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -94,7 +94,7 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
 
   @Nonnull
   BulkWriter bulkWriter() {
-    return new BulkWriter(this, new BulkWriterOptions(true));
+    return new BulkWriter(this, BulkWriterOptions.builder().setThrottlingEnabled(true).build());
   }
 
   @Nonnull

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -94,12 +94,12 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
 
   @Nonnull
   BulkWriter bulkWriter() {
-    return new BulkWriter(this, /* enableThrottling= */ true);
+    return new BulkWriter(this, new BulkWriterOptions(true));
   }
 
   @Nonnull
   BulkWriter bulkWriter(BulkWriterOptions options) {
-    return new BulkWriter(this, options.isThrottlingEnabled());
+    return new BulkWriter(this, options);
   }
 
   @Nonnull

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/RateLimiter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/RateLimiter.java
@@ -38,21 +38,21 @@ class RateLimiter {
   private final double multiplier;
   private final int multiplierMillis;
   private final long startTimeMillis;
-  private final int maximumCapacity;
+  private final int maximumRate;
 
   private int availableTokens;
   private long lastRefillTimeMillis;
 
-  RateLimiter(int initialCapacity, double multiplier, int multiplierMillis, int maximumCapacity) {
-    this(initialCapacity, multiplier, multiplierMillis, maximumCapacity, new Date().getTime());
+  RateLimiter(int initialCapacity, double multiplier, int multiplierMillis, int maximumRate) {
+    this(initialCapacity, multiplier, multiplierMillis, maximumRate, new Date().getTime());
   }
 
   /**
    * @param initialCapacity Initial maximum number of operations per second.
    * @param multiplier Rate by which to increase the capacity.
    * @param multiplierMillis How often the capacity should increase in milliseconds.
-   * @param maximumCapacity Maximum number of allowed operations per second. The number of tokens
-   *     added per second will never exceed this number.
+   * @param maximumRate Maximum number of allowed operations per second. The number of tokens added
+   *     per second will never exceed this number.
    * @param startTimeMillis The starting time in epoch milliseconds that the rate limit is based on.
    *     Used for testing the limiter.
    */
@@ -60,12 +60,12 @@ class RateLimiter {
       int initialCapacity,
       double multiplier,
       int multiplierMillis,
-      int maximumCapacity,
+      int maximumRate,
       long startTimeMillis) {
     this.initialCapacity = initialCapacity;
     this.multiplier = multiplier;
     this.multiplierMillis = multiplierMillis;
-    this.maximumCapacity = maximumCapacity;
+    this.maximumRate = maximumRate;
     this.startTimeMillis = startTimeMillis;
 
     this.availableTokens = initialCapacity;
@@ -76,8 +76,8 @@ class RateLimiter {
     return initialCapacity;
   }
 
-  public int getMaximumCapacity() {
-    return maximumCapacity;
+  public int getMaximumRate() {
+    return maximumRate;
   }
 
   public boolean tryMakeRequest(int numOperations) {
@@ -152,7 +152,7 @@ class RateLimiter {
         Math.min(
             (int)
                 (Math.pow(multiplier, (int) (millisElapsed / multiplierMillis)) * initialCapacity),
-            maximumCapacity);
+            maximumRate);
     return operationsPerSecond;
   }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
@@ -50,7 +50,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -549,8 +548,6 @@ public class BulkWriterTest {
   }
 
   @Test
-  @Ignore
-  // TODO(chenbrian): Fix this test after throttling options are added.
   public void doesNotSendBatchesIfDoingSoExceedsRateLimit() {
     final boolean[] timeoutCalled = {false};
     final ScheduledExecutorService timeoutExecutor =
@@ -565,7 +562,8 @@ public class BulkWriterTest {
           }
         };
     doReturn(timeoutExecutor).when(firestoreRpc).getExecutor();
-    BulkWriter bulkWriter = firestoreMock.bulkWriter();
+    BulkWriter bulkWriter =
+        firestoreMock.bulkWriter(BulkWriterOptions.withInitialOpsPerSecondThrottling(5));
 
     for (int i = 0; i < 600; ++i) {
       bulkWriter.set(firestoreMock.document("coll/doc" + i), LocalFirestoreHelper.SINGLE_FIELD_MAP);

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
@@ -749,7 +749,7 @@ public class BulkWriterTest {
     } catch (Exception e) {
       assertEquals(
           e.getMessage(),
-          "Cannot set 'initialRate' or 'maxRate' when 'throttlingEnabled' is set to false.");
+          "Cannot set 'initialOpsPerSecond' or 'maxOpsPerSecond' when 'throttlingEnabled' is set to false.");
     }
 
     try {
@@ -759,7 +759,7 @@ public class BulkWriterTest {
     } catch (Exception e) {
       assertEquals(
           e.getMessage(),
-          "Cannot set 'initialRate' or 'maxRate' when 'throttlingEnabled' is set to false.");
+          "Cannot set 'initialOpsPerSecond' or 'maxOpsPerSecond' when 'throttlingEnabled' is set to false.");
     }
   }
 
@@ -772,32 +772,32 @@ public class BulkWriterTest {
                 .setMaxOpsPerSecond(550)
                 .build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), 500);
-    assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), 550);
+    assertEquals(bulkWriter.getRateLimiter().getMaximumRate(), 550);
 
     bulkWriter =
         firestoreMock.bulkWriter(BulkWriterOptions.builder().setMaxOpsPerSecond(1000).build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), 500);
-    assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), 1000);
+    assertEquals(bulkWriter.getRateLimiter().getMaximumRate(), 1000);
 
     bulkWriter =
         firestoreMock.bulkWriter(BulkWriterOptions.builder().setInitialOpsPerSecond(100).build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), 100);
-    assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), Integer.MAX_VALUE);
+    assertEquals(bulkWriter.getRateLimiter().getMaximumRate(), Integer.MAX_VALUE);
 
     bulkWriter =
         firestoreMock.bulkWriter(BulkWriterOptions.builder().setMaxOpsPerSecond(100).build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), 100);
-    assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), 100);
+    assertEquals(bulkWriter.getRateLimiter().getMaximumRate(), 100);
 
     bulkWriter = firestoreMock.bulkWriter();
     assertEquals(
         bulkWriter.getRateLimiter().getInitialCapacity(),
         BulkWriter.DEFAULT_STARTING_MAXIMUM_OPS_PER_SECOND);
-    assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), Integer.MAX_VALUE);
+    assertEquals(bulkWriter.getRateLimiter().getMaximumRate(), Integer.MAX_VALUE);
 
     bulkWriter =
         firestoreMock.bulkWriter(BulkWriterOptions.builder().setThrottlingEnabled(false).build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), Integer.MAX_VALUE);
-    assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), Integer.MAX_VALUE);
+    assertEquals(bulkWriter.getRateLimiter().getMaximumRate(), Integer.MAX_VALUE);
   }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
@@ -563,7 +563,7 @@ public class BulkWriterTest {
         };
     doReturn(timeoutExecutor).when(firestoreRpc).getExecutor();
     BulkWriter bulkWriter =
-        firestoreMock.bulkWriter(BulkWriterOptions.withInitialOpsPerSecondThrottling(5));
+        firestoreMock.bulkWriter(BulkWriterOptions.builder().setInitialOpsPerSecond(5).build());
 
     for (int i = 0; i < 600; ++i) {
       bulkWriter.set(firestoreMock.document("coll/doc" + i), LocalFirestoreHelper.SINGLE_FIELD_MAP);
@@ -708,28 +708,29 @@ public class BulkWriterTest {
   @Test
   public void optionsRequiresPositiveInteger() throws Exception {
     try {
-      firestoreMock.bulkWriter(BulkWriterOptions.withInitialOpsPerSecondThrottling(-1));
+      firestoreMock.bulkWriter(BulkWriterOptions.builder().setInitialOpsPerSecond(-1).build());
       fail("bulkWriter() call should have failed");
     } catch (Exception e) {
       assertEquals(
           e.getMessage(),
-          "Value for argument 'initialOpsPerSecond' must be an integer within [1, Infinity], but was: -1");
+          "Value for argument 'initialOpsPerSecond' must be greater than 1, but was: -1");
     }
 
     try {
-      firestoreMock.bulkWriter(BulkWriterOptions.withMaxOpsPerSecondThrottling(-1));
+      firestoreMock.bulkWriter(BulkWriterOptions.builder().setMaxOpsPerSecond(-1).build());
       fail("bulkWriter() call should have failed");
     } catch (Exception e) {
       assertEquals(
           e.getMessage(),
-          "Value for argument 'maxOpsPerSecond' must be an integer within [1, Infinity], but was: -1");
+          "Value for argument 'maxOpsPerSecond' must be greater than 1, but was: -1");
     }
   }
 
   @Test
   public void optionsRequiresMaxGreaterThanInitial() throws Exception {
     try {
-      firestoreMock.bulkWriter(BulkWriterOptions.withCustomThrottling(550, 500));
+      firestoreMock.bulkWriter(
+          BulkWriterOptions.builder().setInitialOpsPerSecond(550).setMaxOpsPerSecond(500).build());
       fail("bulkWriter() call should have failed");
     } catch (Exception e) {
       assertEquals(e.getMessage(), "'maxOpsPerSecond' cannot be less than 'initialOpsPerSecond'.");
@@ -737,21 +738,54 @@ public class BulkWriterTest {
   }
 
   @Test
+  public void cannotSetThrottlingOptionsWithThrottlingDisabled() throws Exception {
+    try {
+      firestoreMock.bulkWriter(
+          BulkWriterOptions.builder()
+              .setThrottlingEnabled(false)
+              .setInitialOpsPerSecond(500)
+              .build());
+      fail("bulkWriter() call should have failed");
+    } catch (Exception e) {
+      assertEquals(
+          e.getMessage(),
+          "Cannot set 'initialRate' or 'maxRate' when 'throttlingEnabled' is set to false.");
+    }
+
+    try {
+      firestoreMock.bulkWriter(
+          BulkWriterOptions.builder().setThrottlingEnabled(false).setMaxOpsPerSecond(500).build());
+      fail("bulkWriter() call should have failed");
+    } catch (Exception e) {
+      assertEquals(
+          e.getMessage(),
+          "Cannot set 'initialRate' or 'maxRate' when 'throttlingEnabled' is set to false.");
+    }
+  }
+
+  @Test
   public void optionsInitialAndMaxRatesAreProperlySet() throws Exception {
     BulkWriter bulkWriter =
-        firestoreMock.bulkWriter(BulkWriterOptions.withCustomThrottling(500, 550));
+        firestoreMock.bulkWriter(
+            BulkWriterOptions.builder()
+                .setInitialOpsPerSecond(500)
+                .setMaxOpsPerSecond(550)
+                .build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), 500);
     assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), 550);
 
-    bulkWriter = firestoreMock.bulkWriter(BulkWriterOptions.withMaxOpsPerSecondThrottling(1000));
+    bulkWriter =
+        firestoreMock.bulkWriter(BulkWriterOptions.builder().setMaxOpsPerSecond(1000).build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), 500);
     assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), 1000);
 
-    bulkWriter = firestoreMock.bulkWriter(BulkWriterOptions.withInitialOpsPerSecondThrottling(100));
+    bulkWriter =
+        firestoreMock.bulkWriter(BulkWriterOptions.builder().setInitialOpsPerSecond(100).build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), 100);
     assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), Integer.MAX_VALUE);
 
-    bulkWriter = firestoreMock.bulkWriter(BulkWriterOptions.withMaxOpsPerSecondThrottling(100));
+    bulkWriter =
+        firestoreMock.bulkWriter(BulkWriterOptions.builder().setMaxOpsPerSecond(100).build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), 100);
     assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), 100);
 
@@ -761,7 +795,8 @@ public class BulkWriterTest {
         BulkWriter.DEFAULT_STARTING_MAXIMUM_OPS_PER_SECOND);
     assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), Integer.MAX_VALUE);
 
-    bulkWriter = firestoreMock.bulkWriter(BulkWriterOptions.withThrottlingDisabled());
+    bulkWriter =
+        firestoreMock.bulkWriter(BulkWriterOptions.builder().setThrottlingEnabled(false).build());
     assertEquals(bulkWriter.getRateLimiter().getInitialCapacity(), Integer.MAX_VALUE);
     assertEquals(bulkWriter.getRateLimiter().getMaximumCapacity(), Integer.MAX_VALUE);
   }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/RateLimiterTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/RateLimiterTest.java
@@ -38,6 +38,7 @@ public class RateLimiterTest {
             /* initialCapacity= */ 500,
             /* multiplier= */ 1.5,
             /* multiplierMillis= */ 5 * 60 * 1000,
+            /* maximumCapacity= */ 1000000,
             /* startTime= */ new Date(0).getTime());
   }
 
@@ -108,5 +109,8 @@ public class RateLimiterTest {
     assertEquals(1125, limiter.calculateCapacity(new Date(10 * 60 * 1000).getTime()));
     assertEquals(1687, limiter.calculateCapacity(new Date(15 * 60 * 1000).getTime()));
     assertEquals(738945, limiter.calculateCapacity(new Date(90 * 60 * 1000).getTime()));
+
+    // Check that maximum rate limit is enforced.
+    assertEquals(1000000, limiter.calculateCapacity(new Date(1000 * 60 * 1000).getTime()));
   }
 }


### PR DESCRIPTION
Porting [throttling options](https://github.com/googleapis/nodejs-firestore/pull/1305) and [rate limiter test fix](https://github.com/googleapis/nodejs-firestore/pull/1307) from node.