### PR TITLE
deps: update dependency com.google.cloud:google-cloud-conformance-tests to v0.0.13

### DIFF
--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-conformance-tests</artifactId>
-      <version>0.0.12</version>
+      <version>0.0.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ConformanceTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ConformanceTest.java
@@ -554,6 +554,9 @@ public class ConformanceTest {
             case ">":
               query = query.whereGreaterThan(fieldPath, value);
               break;
+            case "!=":
+              query = query.whereNotEqualTo(fieldPath, value);
+              break;
             default:
               throw new UnsupportedOperationException();
           }


### PR DESCRIPTION
| Package | Update | Change |
|---|---|---|
| [com.google.cloud:google-cloud-conformance-tests](https://github.com/googleapis/java-conformance-tests) | patch | `0.0.12` -> `0.0.13` |

* Update conformance tests operator handling to no longer error on `!=`
