### PR TITLE
feat: add implicit ordering for startAt(DocumentReference) calls

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
@@ -982,9 +982,14 @@ public class Query {
    */
   @Nonnull
   public Query startAt(Object... fieldValues) {
-    Cursor cursor = createCursor(options.getFieldOrders(), fieldValues, true);
+    ImmutableList<FieldOrder> fieldOrders =
+        fieldValues.length == 1 && fieldValues[0] instanceof DocumentReference
+            ? createImplicitOrderBy()
+            : options.getFieldOrders();
+    Cursor cursor = createCursor(fieldOrders, fieldValues, true);
 
     Builder newOptions = options.toBuilder();
+    newOptions.setFieldOrders(fieldOrders);
     newOptions.setStartCursor(cursor);
     return new Query(rpcContext, newOptions.build());
   }
@@ -1063,9 +1068,14 @@ public class Query {
    * @return The created Query.
    */
   public Query startAfter(Object... fieldValues) {
-    Cursor cursor = createCursor(options.getFieldOrders(), fieldValues, false);
+    ImmutableList<FieldOrder> fieldOrders =
+        fieldValues.length == 1 && fieldValues[0] instanceof DocumentReference
+            ? createImplicitOrderBy()
+            : options.getFieldOrders();
+    Cursor cursor = createCursor(fieldOrders, fieldValues, false);
 
     Builder newOptions = options.toBuilder();
+    newOptions.setFieldOrders(fieldOrders);
     newOptions.setStartCursor(cursor);
     return new Query(rpcContext, newOptions.build());
   }
@@ -1099,9 +1109,14 @@ public class Query {
    */
   @Nonnull
   public Query endBefore(Object... fieldValues) {
-    Cursor cursor = createCursor(options.getFieldOrders(), fieldValues, true);
+    ImmutableList<FieldOrder> fieldOrders =
+        fieldValues.length == 1 && fieldValues[0] instanceof DocumentReference
+            ? createImplicitOrderBy()
+            : options.getFieldOrders();
+    Cursor cursor = createCursor(fieldOrders, fieldValues, true);
 
     Builder newOptions = options.toBuilder();
+    newOptions.setFieldOrders(fieldOrders);
     newOptions.setEndCursor(cursor);
     return new Query(rpcContext, newOptions.build());
   }
@@ -1115,9 +1130,14 @@ public class Query {
    */
   @Nonnull
   public Query endAt(Object... fieldValues) {
-    Cursor cursor = createCursor(options.getFieldOrders(), fieldValues, false);
+    ImmutableList<FieldOrder> fieldOrders =
+        fieldValues.length == 1 && fieldValues[0] instanceof DocumentReference
+            ? createImplicitOrderBy()
+            : options.getFieldOrders();
+    Cursor cursor = createCursor(fieldOrders, fieldValues, false);
 
     Builder newOptions = options.toBuilder();
+    newOptions.setFieldOrders(fieldOrders);
     newOptions.setEndCursor(cursor);
     return new Query(rpcContext, newOptions.build());
   }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.firestore;
 
 import static com.google.cloud.firestore.LocalFirestoreHelper.COLLECTION_ID;
 import static com.google.cloud.firestore.LocalFirestoreHelper.DOCUMENT_NAME;
+import static com.google.cloud.firestore.LocalFirestoreHelper.DOCUMENT_PATH;
 import static com.google.cloud.firestore.LocalFirestoreHelper.SINGLE_FIELD_SNAPSHOT;
 import static com.google.cloud.firestore.LocalFirestoreHelper.endAt;
 import static com.google.cloud.firestore.LocalFirestoreHelper.filter;
@@ -589,6 +590,26 @@ public class QueryTest {
         query(
             order("__name__", StructuredQuery.Direction.ASCENDING),
             startAt(documentBoundary, true));
+
+    assertEquals(queryRequest, runQuery.getValue());
+  }
+
+  @Test
+  public void withDocumentReferenceCursor() {
+    doAnswer(queryResponse())
+        .when(firestoreMock)
+        .streamRequest(
+            runQuery.capture(),
+            streamObserverCapture.capture(),
+            Matchers.<ServerStreamingCallable>any());
+
+    DocumentReference documentCursor = firestoreMock.document(DOCUMENT_PATH);
+    Value documentValue = reference(DOCUMENT_NAME);
+
+    query.startAt(documentCursor).get();
+
+    RunQueryRequest queryRequest =
+        query(order("__name__", StructuredQuery.Direction.ASCENDING), startAt(documentValue, true));
 
     assertEquals(queryRequest, runQuery.getValue());
   }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -544,8 +544,11 @@ public class ITSystemTest {
 
   @Test
   public void startAfterAddsAnImplicitOrderByForDocumentReferences() throws Exception {
-    DocumentReference doc1 = addDocument("foo", 1);
-    DocumentReference doc2 = addDocument("foo", 2);
+    DocumentReference doc1 = randomColl.document("doc1");
+    DocumentReference doc2 = randomColl.document("doc2");
+
+    doc1.set(map("foo", 1)).get();
+    doc2.set(map("foo", 1)).get();
 
     QuerySnapshot querySnapshot = randomColl.startAfter(doc1).get().get();
     assertEquals(1, querySnapshot.size());

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -543,6 +543,17 @@ public class ITSystemTest {
   }
 
   @Test
+  public void startAfterAddsAnImplicitOrderByForDocumentReferences() throws Exception {
+    DocumentReference doc1 = addDocument("foo", 1);
+    DocumentReference doc2 = addDocument("foo", 2);
+
+    QuerySnapshot querySnapshot = randomColl.startAfter(doc1).get().get();
+    assertEquals(1, querySnapshot.size());
+    Iterator<QueryDocumentSnapshot> documents = querySnapshot.iterator();
+    assertEquals(doc2, documents.next().getReference());
+  }
+
+  @Test
   public void endAt() throws Exception {
     addDocument("foo", 1);
     addDocument("foo", 2);


### PR DESCRIPTION
The backend orders every query implicitly by document name, but if a cursor is specified, the order constraint has to be made explicit. This makes the Partition API harder to use, since the user needs to manually "prepend" and orderBy before they can use the cursor values in a QueryPartition.

This PR adds an implicit orderBy if the only cursor value is a DocumentReference. This is based on existing logic for DocumentSnapshots.

Port of https://github.com/googleapis/nodejs-firestore/pull/1328