### PR TITLE
fix: verify page count before invoking QueryPartition RPC

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -604,6 +604,17 @@ public class ITSystemTest {
   }
 
   @Test
+  public void validatesPartitionCount() {
+    StreamConsumer<QueryPartition> consumer = new StreamConsumer<>();
+    try {
+      firestore.collectionGroup(randomColl.getId()).getPartitions(0, consumer);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("Desired partition count must be one or greater", e.getMessage());
+    }
+  }
+
+  @Test
   public void failedTransaction() {
     try {
       firestore


### PR DESCRIPTION
Adding a manual verification for the partition count since we are requesting one less partition from the backend, which creates a confusing error message if the user uses a negative (or zero) partition count.