### PR TITLE
chore: make FirestoreException factory methods public to allow construction for testing

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkCommitBatch.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkCommitBatch.java
@@ -117,7 +117,7 @@ class BulkCommitBatch extends UpdateBuilder<ApiFuture<WriteResult>> {
               if (code == Status.OK) {
                 updateTime = Timestamp.fromProto(writeResult.getUpdateTime());
               } else {
-                exception = FirestoreException.serverRejected(code, status.getMessage());
+                exception = FirestoreException.forServerRejection(code, status.getMessage());
               }
               result.add(new BatchWriteResult(updateTime, exception));
             }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriterOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriterOptions.java
@@ -130,24 +130,24 @@ abstract class BulkWriterOptions {
       Double maxRate = options.getMaxOpsPerSecond();
 
       if (initialRate != null && initialRate < 1) {
-        throw FirestoreException.invalidState(
+        throw FirestoreException.forInvalidArgument(
             "Value for argument 'initialOpsPerSecond' must be greater than 1, but was: "
                 + initialRate.intValue());
       }
 
       if (maxRate != null && maxRate < 1) {
-        throw FirestoreException.invalidState(
+        throw FirestoreException.forInvalidArgument(
             "Value for argument 'maxOpsPerSecond' must be greater than 1, but was: "
                 + maxRate.intValue());
       }
 
       if (maxRate != null && initialRate != null && initialRate > maxRate) {
-        throw FirestoreException.invalidState(
+        throw FirestoreException.forInvalidArgument(
             "'maxOpsPerSecond' cannot be less than 'initialOpsPerSecond'.");
       }
 
       if (!options.getThrottlingEnabled() && (maxRate != null || initialRate != null)) {
-        throw FirestoreException.invalidState(
+        throw FirestoreException.forInvalidArgument(
             "Cannot set 'initialOpsPerSecond' or 'maxOpsPerSecond' when 'throttlingEnabled' is set to false.");
       }
       return options;

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/CollectionGroup.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/CollectionGroup.java
@@ -82,7 +82,7 @@ public class CollectionGroup extends Query {
                     request.build(), rpcContext.getClient().partitionQueryPagedCallable()));
       } catch (ApiException exception) {
         span.setStatus(Status.UNKNOWN.withDescription(exception.getMessage()));
-        throw FirestoreException.apiException(exception);
+        throw FirestoreException.forApiException(exception);
       } finally {
         span.end(TraceUtil.END_SPAN_OPTIONS);
       }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/CollectionReference.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/CollectionReference.java
@@ -149,7 +149,7 @@ public class CollectionReference extends Query {
       response = ApiExceptions.callAndTranslateApiException(future);
     } catch (ApiException exception) {
       span.setStatus(Status.UNKNOWN.withDescription(exception.getMessage()));
-      throw FirestoreException.apiException(exception);
+      throw FirestoreException.forApiException(exception);
     } finally {
       span.end(TraceUtil.END_SPAN_OPTIONS);
     }
@@ -217,7 +217,8 @@ public class CollectionReference extends Query {
   public ApiFuture<DocumentReference> add(Object pojo) {
     Object converted = CustomClassMapper.convertToPlainJavaTypes(pojo);
     if (!(converted instanceof Map)) {
-      throw FirestoreException.invalidState("Can't set a document's data to an array or primitive");
+      throw FirestoreException.forInvalidArgument(
+          "Can't set a document's data to an array or primitive");
     }
     return add((Map<String, Object>) converted);
   }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentReference.java
@@ -393,7 +393,7 @@ public class DocumentReference {
                   request.build(), rpcContext.getClient().listCollectionIdsPagedCallable()));
     } catch (ApiException exception) {
       span.setStatus(Status.UNKNOWN.withDescription(exception.getMessage()));
-      throw FirestoreException.apiException(exception);
+      throw FirestoreException.forApiException(exception);
     } finally {
       span.end(TraceUtil.END_SPAN_OPTIONS);
     }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentTransform.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentTransform.java
@@ -75,7 +75,7 @@ final class DocumentTransform {
             transforms.put(path, fieldValue.toProto(path));
           }
         } else {
-          throw FirestoreException.invalidState(
+          throw FirestoreException.forInvalidArgument(
               fieldValue.getMethodName() + " is not supported inside of an array.");
         }
       } else if (value instanceof Map) {
@@ -94,7 +94,7 @@ final class DocumentTransform {
       Object value = values.get(i);
       path = path.append(FieldPath.of(Integer.toString(i)));
       if (value instanceof FieldValue) {
-        throw FirestoreException.invalidState(
+        throw FirestoreException.forInvalidArgument(
             ((FieldValue) value).getMethodName() + " is not supported inside of an array.");
       } else if (value instanceof Map) {
         extractFromMap((Map<String, Object>) value, path, false);

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreException.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreException.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.firestore;
 
-import com.google.api.core.InternalApi;
+import com.google.api.core.BetaApi;
 import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.grpc.BaseGrpcServiceException;
 import io.grpc.Status;
@@ -55,7 +55,8 @@ public class FirestoreException extends BaseGrpcServiceException {
    *
    * @return The FirestoreException
    */
-  static FirestoreException invalidState(String message, Object... params) {
+  @BetaApi
+  public static FirestoreException forInvalidArgument(String message, Object... params) {
     return new FirestoreException(String.format(message, params), Status.INVALID_ARGUMENT);
   }
 
@@ -65,8 +66,10 @@ public class FirestoreException extends BaseGrpcServiceException {
    *
    * @return The FirestoreException
    */
-  static FirestoreException serverRejected(Status status, String message, Object... params) {
-    return serverRejected(status, null, message, params);
+  @BetaApi
+  public static FirestoreException forServerRejection(
+      Status status, String message, Object... params) {
+    return forServerRejection(status, null, message, params);
   }
 
   /**
@@ -75,7 +78,8 @@ public class FirestoreException extends BaseGrpcServiceException {
    *
    * @return The FirestoreException
    */
-  static FirestoreException serverRejected(
+  @BetaApi
+  public static FirestoreException forServerRejection(
       Status status, @Nullable Throwable cause, String message, Object... params) {
     return new FirestoreException(String.format(message, params), status, cause);
   }
@@ -85,7 +89,8 @@ public class FirestoreException extends BaseGrpcServiceException {
    *
    * @return The FirestoreException
    */
-  static FirestoreException networkException(IOException exception, boolean retryable) {
+  @BetaApi
+  public static FirestoreException forIOException(IOException exception, boolean retryable) {
     return new FirestoreException(exception, retryable);
   }
 
@@ -94,7 +99,8 @@ public class FirestoreException extends BaseGrpcServiceException {
    *
    * @return The FirestoreException
    */
-  static FirestoreException apiException(ApiException exception) {
+  @BetaApi
+  public static FirestoreException forApiException(ApiException exception) {
     return new FirestoreException(exception.getMessage(), exception);
   }
 
@@ -103,13 +109,14 @@ public class FirestoreException extends BaseGrpcServiceException {
    *
    * @return The FirestoreException
    */
-  static FirestoreException apiException(ApiException exception, String message) {
+  @BetaApi
+  public static FirestoreException forApiException(ApiException exception, String message) {
     return new FirestoreException(message, exception);
   }
 
-  @InternalApi
+  @BetaApi
   @Nullable
-  Status getStatus() {
+  public Status getStatus() {
     return status;
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreOptions.java
@@ -88,7 +88,7 @@ public final class FirestoreOptions extends ServiceOptions<Firestore, FirestoreO
       try {
         return new GrpcFirestoreRpc(options);
       } catch (IOException e) {
-        throw FirestoreException.networkException(e, false);
+        throw FirestoreException.forIOException(e, false);
       }
     }
   }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
@@ -406,7 +406,7 @@ public class Query {
       Value encodedValue = encodeValue(fieldReference, sanitizedValue);
 
       if (encodedValue == null) {
-        throw FirestoreException.invalidState(
+        throw FirestoreException.forInvalidArgument(
             "Cannot use FieldValue.delete() or FieldValue.serverTimestamp() in a query boundary");
       }
       result.addValues(encodedValue);
@@ -1434,7 +1434,7 @@ public class Query {
     Value encodedValue =
         UserDataConverter.encodeValue(fieldPath, sanitizedObject, UserDataConverter.ARGUMENT);
     if (encodedValue == null) {
-      throw FirestoreException.invalidState(
+      throw FirestoreException.forInvalidArgument(
           "Cannot use Firestore sentinels in FieldFilter or cursors");
     }
     return encodedValue;

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
@@ -236,14 +236,14 @@ class TransactionRunner<T> {
         } else {
           span.setStatus(TOO_MANY_RETRIES_STATUS);
           final FirestoreException firestoreException =
-              FirestoreException.apiException(
+              FirestoreException.forApiException(
                   apiException, "Transaction was cancelled because of too many retries.");
           return rollbackAndReject(firestoreException);
         }
       } else {
         span.setStatus(TraceUtil.statusFromApiException(apiException));
         final FirestoreException firestoreException =
-            FirestoreException.apiException(
+            FirestoreException.forApiException(
                 apiException, "Transaction failed with non-retryable error");
         return rollbackAndReject(firestoreException);
       }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -172,7 +172,8 @@ public abstract class UpdateBuilder<T> {
   public T create(@Nonnull DocumentReference documentReference, @Nonnull Object pojo) {
     Object data = CustomClassMapper.convertToPlainJavaTypes(pojo);
     if (!(data instanceof Map)) {
-      throw FirestoreException.invalidState("Can't set a document's data to an array or primitive");
+      throw FirestoreException.forInvalidArgument(
+          "Can't set a document's data to an array or primitive");
     }
     return performCreate(documentReference, (Map<String, Object>) data);
   }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UserDataConverter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UserDataConverter.java
@@ -181,7 +181,8 @@ class UserDataConverter {
       }
     }
 
-    throw FirestoreException.invalidState("Cannot convert %s to Firestore Value", sanitizedObject);
+    throw FirestoreException.forInvalidArgument(
+        "Cannot convert %s to Firestore Value", sanitizedObject);
   }
 
   static Object decodeValue(FirestoreRpcContext<?> rpcContext, Value v) {
@@ -222,7 +223,8 @@ class UserDataConverter {
         }
         return outputMap;
       default:
-        throw FirestoreException.invalidState(String.format("Unknown Value Type: %s", typeCase));
+        throw FirestoreException.forInvalidArgument(
+            String.format("Unknown Value Type: %s", typeCase));
     }
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Watch.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Watch.java
@@ -184,7 +184,7 @@ class Watch implements ApiStreamObserver<ListenResponse> {
             break;
           case ADD:
             if (WATCH_TARGET_ID != change.getTargetIds(0)) {
-              closeStream(FirestoreException.invalidState("Target ID must be 0x01"));
+              closeStream(FirestoreException.forInvalidArgument("Target ID must be 0x01"));
             }
             break;
           case REMOVE:
@@ -193,7 +193,7 @@ class Watch implements ApiStreamObserver<ListenResponse> {
                     ? Status.fromCodeValue(change.getCause().getCode())
                     : Status.CANCELLED;
             closeStream(
-                FirestoreException.serverRejected(
+                FirestoreException.forServerRejection(
                     status, "Backend ended Listen stream: " + change.getCause().getMessage()));
             break;
           case CURRENT:
@@ -204,7 +204,7 @@ class Watch implements ApiStreamObserver<ListenResponse> {
             break;
           default:
             closeStream(
-                FirestoreException.invalidState(
+                FirestoreException.forInvalidArgument(
                     "Encountered invalid target change type: " + change.getTargetChangeType()));
         }
 
@@ -247,7 +247,8 @@ class Watch implements ApiStreamObserver<ListenResponse> {
         }
         break;
       default:
-        closeStream(FirestoreException.invalidState("Encountered invalid listen response type"));
+        closeStream(
+            FirestoreException.forInvalidArgument("Encountered invalid listen response type"));
         break;
     }
   }
@@ -340,7 +341,7 @@ class Watch implements ApiStreamObserver<ListenResponse> {
                   null,
                   throwable instanceof FirestoreException
                       ? (FirestoreException) throwable
-                      : FirestoreException.apiException(
+                      : FirestoreException.forApiException(
                           new ApiException(
                               throwable,
                               GrpcStatusCode.of(getStatus(throwable).getCode()),

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
@@ -997,7 +997,7 @@ public class BulkWriterTest {
   public void individualWritesErrorIfBulkCommitFails() throws Exception {
     doReturn(
             ApiFutures.immediateFailedFuture(
-                FirestoreException.serverRejected(
+                FirestoreException.forServerRejection(
                     Status.DEADLINE_EXCEEDED, "Mock batchWrite failed in test")))
         .when(firestoreMock)
         .sendRequest(
@@ -1049,7 +1049,7 @@ public class BulkWriterTest {
   @Test
   public void retriesWritesWhenBatchWriteFailsWithRetryableError() throws Exception {
     FirestoreException retryableError =
-        FirestoreException.serverRejected(
+        FirestoreException.forServerRejection(
             Status.fromCode(Status.Code.ABORTED), "Mock batchWrite failed in test");
 
     ApiFuture<Void> errorFuture = ApiFutures.immediateFailedFuture(retryableError);
@@ -1077,7 +1077,7 @@ public class BulkWriterTest {
               public ApiFuture<Object> answer(InvocationOnMock mock) {
                 retryAttempts[0]++;
                 return ApiFutures.immediateFailedFuture(
-                    FirestoreException.serverRejected(
+                    FirestoreException.forServerRejection(
                         Status.fromCode(Status.Code.ABORTED), "Mock batchWrite failed in test"));
               }
             })

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -938,7 +938,7 @@ public class QueryTest {
                 if (returnError[0]) {
                   returnError[0] = false;
                   return queryResponse(
-                          FirestoreException.serverRejected(
+                          FirestoreException.forServerRejection(
                               Status.DEADLINE_EXCEEDED, "Simulated test failure"),
                           DOCUMENT_NAME + "1",
                           DOCUMENT_NAME + "2")
@@ -998,7 +998,7 @@ public class QueryTest {
   public void doesNotRetryAfterNonRetryableError() throws Exception {
     doAnswer(
             queryResponse(
-                FirestoreException.serverRejected(
+                FirestoreException.forServerRejection(
                     Status.PERMISSION_DENIED, "Simulated test failure"),
                 DOCUMENT_NAME + "1",
                 DOCUMENT_NAME + "2"))


### PR DESCRIPTION
* Expose each factory method at @BetaApi level ensuring no guarantee about api surface
* Expose getStatus() at @BetaApi up from package private @InternalApi