### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ target/
 .idea/
 *.iml
 __pycache__/
-
+.DS_Store
 .flattened-pom.xml


### PR DESCRIPTION
Someone, I kept adding .DS_Store files throughout the repo on `mvn clean install`.