### PR TITLE
build: fix version tags to use correct values

### DIFF
--- a/google-cloud-firestore-bom/pom.xml
+++ b/google-cloud-firestore-bom/pom.xml
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>proto-google-cloud-firestore-bundle-v1</artifactId>
-        <version>2.1.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-firestore:current} -->
+        <version>2.1.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>proto-google-cloud-firestore-bundle-v1</artifactId>
-        <version>2.1.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-firestore:current} -->
+        <version>2.1.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
Fixes broken builds from #369 visible in https://github.com/googleapis/java-firestore/pull/369/checks?check_run_id=1710823233