### PR TITLE
fix: don't throw NPE in DocumentSnapshot.getDate() when value is missing

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentSnapshot.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentSnapshot.java
@@ -345,7 +345,8 @@ public class DocumentSnapshot {
    */
   @Nullable
   public Date getDate(@Nonnull String field) {
-    return ((Timestamp) get(field)).toDate();
+    Timestamp timestamp = (Timestamp) get(field);
+    return timestamp == null ? null : timestamp.toDate();
   }
 
   /**

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentSnapshot.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentSnapshot.java
@@ -345,7 +345,7 @@ public class DocumentSnapshot {
    */
   @Nullable
   public Date getDate(@Nonnull String field) {
-    Timestamp timestamp = (Timestamp) get(field);
+    Timestamp timestamp = getTimestamp(field);
     return timestamp == null ? null : timestamp.toDate();
   }
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/java-firestore/issues/491