### PR TITLE
test: Update assertion in failing test: ITSystemTest.readOnlyTransaction_failureWhenAttemptReadOlderThan60Seconds

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -1535,7 +1535,7 @@ public class ITSystemTest {
       final StatusRuntimeException invalidArgument = (StatusRuntimeException) rootCause;
       final Status status = invalidArgument.getStatus();
       assertThat(status.getCode()).isEqualTo(Code.FAILED_PRECONDITION);
-      assertThat(status.getDescription()).contains("old");
+      assertThat(status.getDescription()).contains("minimum");
     }
   }
 


### PR DESCRIPTION
It appears that the message from the server has changed, causing one of the assertion checks to fail.

This commit updates the assertion to fix the test failure.

Fixes #588