### PR TITLE
fix: add flush check in BulkWriter.sendBatchLocked() callback

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
@@ -989,7 +989,9 @@ public final class BulkWriter implements AutoCloseable {
                 @Override
                 public void run() {
                   synchronized (lock) {
-                    scheduleCurrentBatchLocked(flush);
+                    if (flush) {
+                      scheduleCurrentBatchLocked(/* flush= */ true);
+                    }
                   }
                 }
               },

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BulkWriter.java
@@ -988,8 +988,8 @@ public final class BulkWriter implements AutoCloseable {
               new Runnable() {
                 @Override
                 public void run() {
-                  synchronized (lock) {
-                    if (flush) {
+                  if (flush) {
+                    synchronized (lock) {
                       scheduleCurrentBatchLocked(/* flush= */ true);
                     }
                   }


### PR DESCRIPTION
Found this bug while adding recursive delete tests. I tried to think of a way to add a unit test to check for this, but I couldn't think of an easy test since `scheduleCurrentBatchLocked()` automatically returns if there are no mutations.

However, not having this check was causing the `startAfter()` recursive delete test to flake, so that's some indirect coverage 😨 