### PR TITLE
test(fix): remove assertion on error message for reads older than 60 seconds

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -1537,7 +1537,6 @@ public class ITSystemTest {
       final StatusRuntimeException invalidArgument = (StatusRuntimeException) rootCause;
       final Status status = invalidArgument.getStatus();
       assertThat(status.getCode()).isEqualTo(Code.FAILED_PRECONDITION);
-      assertThat(status.getDescription()).isEqualTo("The requested snapshot version is too old.");
     }
   }
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -1537,7 +1537,7 @@ public class ITSystemTest {
       final StatusRuntimeException invalidArgument = (StatusRuntimeException) rootCause;
       final Status status = invalidArgument.getStatus();
       assertThat(status.getCode()).isEqualTo(Code.FAILED_PRECONDITION);
-      assertThat(status.getDescription()).contains("minimum");
+      assertThat(status.getDescription()).isEqualTo("The requested snapshot version is too old.");
     }
   }
 


### PR DESCRIPTION
It seems like the error message for this has been updated.