### PR TITLE
fix: handle thrown exceptions in runAsyncTransaction callback

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/TransactionRunner.java
@@ -153,15 +153,7 @@ class TransactionRunner<T> {
           public void run() {
             try {
               ApiFutures.addCallback(
-                  ApiFutures.catchingAsync(
-                      userCallback.updateCallback(transaction),
-                      Throwable.class,
-                      new ApiAsyncFunction<Throwable, T>() {
-                        public ApiFuture<T> apply(Throwable throwable) throws Exception {
-                          return ApiFutures.immediateFailedFuture(throwable);
-                        }
-                      },
-                      MoreExecutors.directExecutor()),
+                  userCallback.updateCallback(transaction),
                   new ApiFutureCallback<T>() {
                     @Override
                     public void onFailure(Throwable t) {

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -689,6 +689,24 @@ public class ITSystemTest {
   }
 
   @Test
+  public void asyncTxFailsWithUserError() throws Exception {
+    try {
+      firestore
+          .runAsyncTransaction(
+              new Transaction.AsyncFunction<String>() {
+                @Override
+                public ApiFuture<String> updateCallback(Transaction transaction) {
+                  throw new RuntimeException("User exception");
+                }
+              })
+          .get();
+      fail();
+    } catch (Exception e) {
+      assertTrue(e.getMessage().endsWith("User exception"));
+    }
+  }
+
+  @Test
   public void doesNotRetryTransactionsWithFailedPreconditions() {
     final DocumentReference documentReference = randomColl.document();
 


### PR DESCRIPTION
Fixes #667.

The callback `onFailure` is only triggered if the ApiFuture contains the exception. When a runtime exception is thrown neither the `onFailure` nor `onSuccess` handler is called, leading the ApiFuture to hang and never complete.

The fix adds a `catchingAsync()` around `updateCallback` to guard against thrown exceptions. Added a system test for redundancy, but I can remove it. Both tests fail (never complete) when run against master. 