### PR TITLE
fix: close the Watch stream when we receive an error

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -21,8 +21,12 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.NanoClock;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.BidiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStream;
+import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamController;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.spi.v1.FirestoreRpc;
@@ -201,7 +205,6 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
     return this.getAll(documentReferences, fieldMask, (ByteString) null);
   }
 
-  @Nonnull
   @Override
   public void getAll(
       final @Nonnull DocumentReference[] documentReferences,
@@ -216,12 +219,15 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
       @Nullable ByteString transactionId,
       final ApiStreamObserver<DocumentSnapshot> apiStreamObserver) {
 
-    ApiStreamObserver<BatchGetDocumentsResponse> responseObserver =
-        new ApiStreamObserver<BatchGetDocumentsResponse>() {
+    ResponseObserver<BatchGetDocumentsResponse> responseObserver =
+        new ResponseObserver<BatchGetDocumentsResponse>() {
           int numResponses;
 
           @Override
-          public void onNext(BatchGetDocumentsResponse response) {
+          public void onStart(StreamController streamController) {}
+
+          @Override
+          public void onResponse(BatchGetDocumentsResponse response) {
             DocumentReference documentReference;
             DocumentSnapshot documentSnapshot;
 
@@ -270,7 +276,7 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
           }
 
           @Override
-          public void onCompleted() {
+          public void onComplete() {
             tracer
                 .getCurrentSpan()
                 .addAnnotation(TraceUtil.SPAN_NAME_BATCHGETDOCUMENTS + ": Complete");
@@ -433,19 +439,19 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
   @Override
   public <RequestT, ResponseT> void streamRequest(
       RequestT requestT,
-      ApiStreamObserver<ResponseT> responseObserverT,
+      ResponseObserver<ResponseT> responseObserverT,
       ServerStreamingCallable<RequestT, ResponseT> callable) {
     Preconditions.checkState(!closed, "Firestore client has already been closed");
-    callable.serverStreamingCall(requestT, responseObserverT);
+    callable.call(requestT, responseObserverT);
   }
 
   /** Request funnel for all bidirectional streaming requests. */
   @Override
-  public <RequestT, ResponseT> ApiStreamObserver<RequestT> streamRequest(
-      ApiStreamObserver<ResponseT> responseObserverT,
+  public <RequestT, ResponseT> ClientStream<RequestT> streamRequest(
+      BidiStreamObserver<RequestT, ResponseT> responseObserverT,
       BidiStreamingCallable<RequestT, ResponseT> callable) {
     Preconditions.checkState(!closed, "Firestore client has already been closed");
-    return callable.bidiStreamingCall(responseObserverT);
+    return callable.splitCall(responseObserverT);
   }
 
   @Override

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreRpcContext.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreRpcContext.java
@@ -20,8 +20,10 @@ import com.google.api.core.ApiClock;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.api.core.InternalExtensionOnly;
-import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.BidiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStream;
+import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.firestore.spi.v1.FirestoreRpc;
@@ -48,10 +50,10 @@ interface FirestoreRpcContext<FS extends Firestore> {
 
   <RequestT, ResponseT> void streamRequest(
       RequestT requestT,
-      ApiStreamObserver<ResponseT> responseObserverT,
+      ResponseObserver<ResponseT> responseObserverT,
       ServerStreamingCallable<RequestT, ResponseT> callable);
 
-  <RequestT, ResponseT> ApiStreamObserver<RequestT> streamRequest(
-      ApiStreamObserver<ResponseT> responseObserverT,
+  <RequestT, ResponseT> ClientStream<RequestT> streamRequest(
+      BidiStreamObserver<RequestT, ResponseT> responseObserverT,
       BidiStreamingCallable<RequestT, ResponseT> callable);
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/BulkWriterTest.java
@@ -70,7 +70,6 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BulkWriterTest {
@@ -1119,11 +1118,10 @@ public class BulkWriterTest {
         };
 
     doAnswer(
-            (Answer<ApiFuture<GeneratedMessageV3>>)
-                mock -> {
-                  retryAttempts[0]++;
-                  return RETRYABLE_FAILED_FUTURE;
-                })
+            mock -> {
+              retryAttempts[0]++;
+              return RETRYABLE_FAILED_FUTURE;
+            })
         .when(firestoreMock)
         .sendRequest(
             batchWriteCapture.capture(),
@@ -1170,11 +1168,10 @@ public class BulkWriterTest {
         };
 
     doAnswer(
-            (Answer<ApiFuture<GeneratedMessageV3>>)
-                mock -> {
-                  retryAttempts[0]++;
-                  return RESOURCE_EXHAUSTED_FAILED_FUTURE;
-                })
+            mock -> {
+              retryAttempts[0]++;
+              return RESOURCE_EXHAUSTED_FAILED_FUTURE;
+            })
         .when(firestoreMock)
         .sendRequest(
             batchWriteCapture.capture(),

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/DocumentReferenceTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/DocumentReferenceTest.java
@@ -64,7 +64,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 
-import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.Timestamp;
@@ -111,7 +111,7 @@ public class DocumentReferenceTest {
 
   @Captor private ArgumentCaptor<BatchGetDocumentsRequest> getAllCapture;
 
-  @Captor private ArgumentCaptor<ApiStreamObserver> streamObserverCapture;
+  @Captor private ArgumentCaptor<ResponseObserver<CommitResponse>> streamObserverCapture;
 
   private DocumentReference documentReference;
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/FirestoreTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/FirestoreTest.java
@@ -32,14 +32,14 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 
-import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.firestore.spi.v1.FirestoreRpc;
 import com.google.firestore.v1.BatchGetDocumentsRequest;
 import com.google.firestore.v1.CommitRequest;
 import com.google.firestore.v1.CommitResponse;
-import com.google.firestore.v1.ListCollectionIdsRequest;
+import com.google.protobuf.Message;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -64,9 +64,7 @@ public class FirestoreTest {
 
   @Captor private ArgumentCaptor<BatchGetDocumentsRequest> getAllCapture;
 
-  @Captor private ArgumentCaptor<ListCollectionIdsRequest> listCollectionIdsCapture;
-
-  @Captor private ArgumentCaptor<ApiStreamObserver> streamObserverCapture;
+  @Captor private ArgumentCaptor<ResponseObserver<Message>> streamObserverCapture;
 
   @Captor private ArgumentCaptor<CommitRequest> commitCapture;
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.doAnswer;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.Timestamp;
 import com.google.common.base.Preconditions;
@@ -316,14 +316,14 @@ public final class LocalFirestoreHelper {
       final T[] response, @Nullable final Throwable throwable) {
     return invocation -> {
       Object[] args = invocation.getArguments();
-      ApiStreamObserver<T> observer = (ApiStreamObserver<T>) args[1];
+      ResponseObserver<T> observer = (ResponseObserver<T>) args[1];
       for (T resp : response) {
-        observer.onNext(resp);
+        observer.onResponse(resp);
       }
       if (throwable != null) {
         observer.onError(throwable);
       }
-      observer.onCompleted();
+      observer.onComplete();
       return null;
     };
   }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/PartitionQuery.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/PartitionQuery.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
-import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.firestore.spi.v1.FirestoreRpc;
@@ -75,7 +75,7 @@ public class PartitionQuery {
   @Mock private PartitionQueryPage queryPage;
 
   @Captor private ArgumentCaptor<RunQueryRequest> runQuery;
-  @Captor private ArgumentCaptor<ApiStreamObserver> streamObserverCapture;
+  @Captor private ArgumentCaptor<ResponseObserver<PartitionQueryResponse>> streamObserverCapture;
   @Captor private ArgumentCaptor<PartitionQueryRequest> requestCaptor;
 
   @Test

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
@@ -47,7 +47,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.rpc.ApiException;
-import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.Timestamp;
@@ -100,7 +100,7 @@ public class TransactionTest {
           firestoreRpc);
 
   @Captor private ArgumentCaptor<Message> requestCapture;
-  @Captor private ArgumentCaptor<ApiStreamObserver<Message>> streamObserverCapture;
+  @Captor private ArgumentCaptor<ResponseObserver<Message>> streamObserverCapture;
 
   private DocumentReference documentReference;
   private Query queryReference;

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WatchTest.java
@@ -280,6 +280,8 @@ public class WatchTest {
     awaitAddTarget();
     send(removeTarget(Code.PERMISSION_DENIED));
     awaitClose();
+
+    awaitException(Code.PERMISSION_DENIED);
   }
 
   @Test

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WatchTest.java
@@ -274,6 +274,15 @@ public class WatchTest {
   }
 
   @Test
+  public void queryWatchShutsDownStreamOnPermissionDenied() throws InterruptedException {
+    addQueryListener();
+
+    awaitAddTarget();
+    send(removeTarget(Code.PERMISSION_DENIED));
+    awaitClose();
+  }
+
+  @Test
   public void queryWatchReopensOnUnexceptedStreamEnd() throws InterruptedException {
     addQueryListener();
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WatchTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/WatchTest.java
@@ -29,12 +29,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 
-import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.BidiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStream;
 import com.google.cloud.firestore.Query.Direction;
 import com.google.cloud.firestore.WatchTest.SnapshotDocument.ChangeType;
 import com.google.cloud.firestore.spi.v1.FirestoreRpc;
@@ -103,7 +103,8 @@ public class WatchTest {
               .build(),
           firestoreRpc);
 
-  @Captor private ArgumentCaptor<ApiStreamObserver<ListenResponse>> streamObserverCapture;
+  @Captor
+  private ArgumentCaptor<BidiStreamObserver<ListenRequest, ListenResponse>> streamObserverCapture;
 
   /** Executor that executes delayed tasks without delay. */
   private final ScheduledExecutorService immediateExecutor =
@@ -975,7 +976,7 @@ public class WatchTest {
   }
 
   private void send(ListenResponse response) {
-    streamObserverCapture.getValue().onNext(response);
+    streamObserverCapture.getValue().onResponse(response);
   }
 
   private void destroy(Code code) {
@@ -983,26 +984,29 @@ public class WatchTest {
   }
 
   private void close() {
-    streamObserverCapture.getValue().onCompleted();
+    streamObserverCapture.getValue().onComplete();
   }
 
   /** Returns a new request observer that persists its input. */
-  private Answer newRequestObserver() {
+  private Answer<ClientStream<ListenRequest>> newRequestObserver() {
     return invocationOnMock ->
-        new ApiStreamObserver<ListenRequest>() {
+        new ClientStream<ListenRequest>() {
           @Override
-          public void onNext(ListenRequest listenRequest) {
+          public void send(ListenRequest listenRequest) {
             requests.add(listenRequest);
           }
 
           @Override
-          public void onError(Throwable throwable) {
-            fail("Received unexpected error");
+          public void closeSendWithError(Throwable throwable) {}
+
+          @Override
+          public void closeSend() {
+            closes.release();
           }
 
           @Override
-          public void onCompleted() {
-            closes.release();
+          public boolean isSendReady() {
+            return true;
           }
         };
   }


### PR DESCRIPTION
The Watch code called "onCompleted" to close the stream - but that did not actually do anything. This PR migrates our streaming GAPIC APIs to ClientStream (which is not deprecated) and then calls "close()" instead.

Fixes: https://github.com/googleapis/java-firestore/issues/822