### PR TITLE
fix(java): add reflection configuration for native image tests

### DIFF
--- a/google-cloud-firestore/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/google-cloud-firestore/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,40 @@
+[{
+  "name":"com.google.cloud.firestore.LocalFirestoreHelper$AllSupportedTypes",
+  "allDeclaredFields":true,
+  "allPublicFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllPublicMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]}
+,
+{
+"name":"com.google.cloud.firestore.LocalFirestoreHelper$CustomList",
+"allDeclaredFields":true,
+"allPublicFields":true,
+"queryAllDeclaredMethods":true,
+"queryAllPublicMethods":true,
+"methods":[{"name":"<init>","parameterTypes":[] }]}
+,
+{
+"name":"com.google.cloud.firestore.LocalFirestoreHelper$CustomMap",
+"allDeclaredFields":true,
+"allPublicFields":true,
+"queryAllDeclaredMethods":true,
+"queryAllPublicMethods":true,
+"methods":[{"name":"<init>","parameterTypes":[] }]}
+,
+{
+"name":"com.google.cloud.firestore.LocalFirestoreHelper$FooList",
+"methods":[{"name":"<init>","parameterTypes":[] }]}
+,
+{
+"name":"com.google.cloud.firestore.LocalFirestoreHelper$FooMap",
+"methods":[{"name":"<init>","parameterTypes":[] }]}
+,
+{
+"name":"com.google.cloud.firestore.LocalFirestoreHelper$SingleField",
+"allDeclaredFields":true,
+"allPublicFields":true,
+"queryAllDeclaredMethods":true,
+"queryAllPublicMethods":true,
+"methods":[{"name":"<init>","parameterTypes":[] }]}
+]


### PR DESCRIPTION
Currently running `mvn test -Pnative` is resulting in the following errors:
```
JUnit Vintage:ITSystemTest:setDocumentWithFloat
    MethodSource [className = 'com.google.cloud.firestore.it.ITSystemTest', methodName = 'setDocumentWithFloat', methodParameterTypes = '']
    => java.lang.RuntimeException: No properties to serialize found on class com.google.cloud.firestore.LocalFirestoreHelper$SingleField
       com.google.cloud.firestore.CustomClassMapper$BeanMapper.<init>(CustomClassMapper.java:765)
       com.google.cloud.firestore.CustomClassMapper.loadOrCreateBeanMapperForClass(CustomClassMapper.java:410)
       com.google.cloud.firestore.CustomClassMapper.convertBean(CustomClassMapper.java:591)
       com.google.cloud.firestore.CustomClassMapper.deserializeToClass(CustomClassMapper.java:256)
       com.google.cloud.firestore.CustomClassMapper.convertToCustomClass(CustomClassMapper.java:100)
       com.google.cloud.firestore.DocumentSnapshot.toObject(DocumentSnapshot.java:189)
       com.google.cloud.firestore.it.ITSystemTest.setDocumentWithFloat(ITSystemTest.java:258)
       java.lang.reflect.Method.invoke(Method.java:566)
       org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
       org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
       [...]
  JUnit Vintage:ITSystemTest:setDocumentWithValue
    MethodSource [className = 'com.google.cloud.firestore.it.ITSystemTest', methodName = 'setDocumentWithValue', methodParameterTypes = '']
    => java.lang.RuntimeException: No properties to serialize found on class com.google.cloud.firestore.LocalFirestoreHelper$SingleField
       com.google.cloud.firestore.CustomClassMapper$BeanMapper.<init>(CustomClassMapper.java:765)
       com.google.cloud.firestore.CustomClassMapper.loadOrCreateBeanMapperForClass(CustomClassMapper.java:410)
       com.google.cloud.firestore.CustomClassMapper.convertBean(CustomClassMapper.java:591)
       com.google.cloud.firestore.CustomClassMapper.deserializeToClass(CustomClassMapper.java:256)
       com.google.cloud.firestore.CustomClassMapper.convertToCustomClass(CustomClassMapper.java:100)
       com.google.cloud.firestore.DocumentSnapshot.toObject(DocumentSnapshot.java:189)
       com.google.cloud.firestore.it.ITSystemTest.setDocumentWithValue(ITSystemTest.java:250)
       java.lang.reflect.Method.invoke(Method.java:566)
       org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
       org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
       [...]
  JUnit Vintage:ITSystemTest:createDocument
    MethodSource [className = 'com.google.cloud.firestore.it.ITSystemTest', methodName = 'createDocument', methodParameterTypes = '']
    => java.lang.RuntimeException: No properties to serialize found on class com.google.cloud.firestore.LocalFirestoreHelper$SingleField
       com.google.cloud.firestore.CustomClassMapper$BeanMapper.<init>(CustomClassMapper.java:765)
       com.google.cloud.firestore.CustomClassMapper.loadOrCreateBeanMapperForClass(CustomClassMapper.java:410)
       com.google.cloud.firestore.CustomClassMapper.convertBean(CustomClassMapper.java:591)
       com.google.cloud.firestore.CustomClassMapper.deserializeToClass(CustomClassMapper.java:256)
       com.google.cloud.firestore.CustomClassMapper.convertToCustomClass(CustomClassMapper.java:100)
       com.google.cloud.firestore.DocumentSnapshot.toObject(DocumentSnapshot.java:189)
       com.google.cloud.firestore.it.ITSystemTest.createDocument(ITSystemTest.java:215)
       java.lang.reflect.Method.invoke(Method.java:566)
       org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
       org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
       [...]
```

This PR  registers `com.google.cloud.firestore.LocalFirestoreHelper` and its inner classes for reflection through the use of a `reflect-config.json` file in order to address this issue. 