### PR TITLE
docs(sample): Use Java 8 for native image sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-firestore'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-firestore:3.0.13'
+implementation 'com.google.cloud:google-cloud-firestore:3.0.14'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.0.13"
+libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.0.14"
 ```
 
 ## Authentication

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -66,8 +66,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
         <configuration>
           <archive>
             <manifest>
-              <mainClass>com.example.firestore.NativeImageFirestoreSample
-              </mainClass>
+              <mainClass>com.example.firestore.NativeImageFirestoreSample</mainClass>
             </manifest>
           </archive>
         </configuration>
@@ -119,8 +118,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
             <version>0.9.10</version>
             <extensions>true</extensions>
             <configuration>
-              <mainClass>com.example.firestore.NativeImageFirestoreSample
-              </mainClass>
+              <mainClass>com.example.firestore.NativeImageFirestoreSample</mainClass>
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -20,8 +20,9 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <!-- Java 8 because the Kokoro Sample test uses that Java version -->
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
This should fix the Native Image sample which is failing with the following error:

![Screen Shot 2022-03-01 at 5 02 36 PM](https://user-images.githubusercontent.com/66699525/156256394-0515483b-226b-44df-93e1-a882ac78201d.png)

