### PR TITLE
fix(java): fix native image Kokoro test setup

### DIFF
--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -12,16 +12,16 @@ env_vars: {
 }
 
 env_vars: {
-    key: "GCLOUD_PROJECT"
-    value: "java-review"
+  key: "GCLOUD_PROJECT"
+  value: "java-review"
 }
 
 env_vars: {
-    key: "GOOGLE_APPLICATION_CREDENTIALS"
-    value: "secret_manager/java-review_firestore-java-it"
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-review_firestore-java-it"
 }
 
 env_vars: {
-    key: "SECRET_MANAGER_KEYS"
-    value: "java-review_firestore-java-it"
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-review_firestore-java-it"
 }

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -11,23 +11,17 @@ env_vars: {
   value: "graalvm"
 }
 
-# TODO: remove this after we've migrated all tests and scripts
 env_vars: {
-  key: "GCLOUD_PROJECT"
-  value: "gcloud-devel"
+    key: "GCLOUD_PROJECT"
+    value: "java-review"
 }
 
 env_vars: {
-  key: "GOOGLE_CLOUD_PROJECT"
-  value: "gcloud-devel"
+    key: "GOOGLE_APPLICATION_CREDENTIALS"
+    value: "secret_manager/java-review_firestore-java-it"
 }
 
 env_vars: {
-  key: "GOOGLE_APPLICATION_CREDENTIALS"
-  value: "secret_manager/java-it-service-account"
-}
-
-env_vars: {
-  key: "SECRET_MANAGER_KEYS"
-  value: "java-it-service-account"
+    key: "SECRET_MANAGER_KEYS"
+    value: "java-review_firestore-java-it"
 }

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-firestore'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-firestore:3.0.17'
+implementation 'com.google.cloud:google-cloud-firestore:3.0.18'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.0.17"
+libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.0.18"
 ```
 
 ## Authentication

--- a/google-cloud-firestore/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/google-cloud-firestore/src/main/resources/META-INF/native-image/reflect-config.json
@@ -2,24 +2,24 @@
   "name":"com.google.cloud.firestore.LocalFirestoreHelper$AllSupportedTypes",
   "allDeclaredFields":true,
   "allPublicFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllPublicMethods":true,
+  "allDeclaredMethods":true,
+  "allPublicMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,
 {
 "name":"com.google.cloud.firestore.LocalFirestoreHelper$CustomList",
 "allDeclaredFields":true,
 "allPublicFields":true,
-"queryAllDeclaredMethods":true,
-"queryAllPublicMethods":true,
+"allDeclaredMethods":true,
+"allPublicMethods":true,
 "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,
 {
 "name":"com.google.cloud.firestore.LocalFirestoreHelper$CustomMap",
 "allDeclaredFields":true,
 "allPublicFields":true,
-"queryAllDeclaredMethods":true,
-"queryAllPublicMethods":true,
+"allDeclaredMethods":true,
+"allPublicMethods":true,
 "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,
 {

--- a/google-cloud-firestore/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/google-cloud-firestore/src/main/resources/META-INF/native-image/reflect-config.json
@@ -34,7 +34,7 @@
 "name":"com.google.cloud.firestore.LocalFirestoreHelper$SingleField",
 "allDeclaredFields":true,
 "allPublicFields":true,
-"queryAllDeclaredMethods":true,
-"queryAllPublicMethods":true,
+"allDeclaredMethods":true,
+"allPublicMethods":true,
 "methods":[{"name":"<init>","parameterTypes":[] }]}
 ]

--- a/owlbot.py
+++ b/owlbot.py
@@ -79,6 +79,7 @@ java.common_templates(excludes=[
     # firestore uses a different project for its integration tests
     # due to the default project running datastore
     '.kokoro/presubmit/integration.cfg',
+    '.kokoro/presubmit/graalvm-native.cfg',
     '.kokoro/presubmit/samples.cfg',
     '.kokoro/nightly/integration.cfg',
     '.kokoro/nightly/java11-integration.cfg',


### PR DESCRIPTION
This PR makes the Kokoro presubmit setup for Graal tests consistent with that of the standard Java integration tests. 
This should help address the following failure in the Kokoro GraalVM presubmit job:

```
java.util.concurrent.ExecutionException: com.google.api.gax.rpc.FailedPreconditionException: io.grpc.StatusRuntimeException: FAILED_PRECONDITION: The Cloud Firestore API is not available for Cloud Datastore projects.
```

cc @meltsufin 
