### PR TITLE
feat: add logical termination for RunQueryResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-firestore'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-firestore:3.1.0'
+implementation 'com.google.cloud:google-cloud-firestore:3.2.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.1.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.2.0"
 ```
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.2.0')
+implementation platform('com.google.cloud:libraries-bom:25.3.0')
 
 implementation 'com.google.cloud:google-cloud-firestore'
 ```

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
@@ -1330,6 +1330,8 @@ public class Query {
 
     internalStream(
         new QuerySnapshotObserver() {
+          boolean hasCompleted = false;
+
           @Override
           public void onNext(QueryDocumentSnapshot documentSnapshot) {
             responseObserver.onNext(documentSnapshot);
@@ -1342,6 +1344,8 @@ public class Query {
 
           @Override
           public void onCompleted() {
+            if (hasCompleted) return;
+            hasCompleted = true;
             responseObserver.onCompleted();
           }
         },

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
@@ -312,7 +312,8 @@ public final class LocalFirestoreHelper {
   }
 
   /** Returns a stream of responses when RunQueryResponse.done set to true */
-  public static Answer<RunQueryResponse> queryResponse(boolean setDone, String... documentNames) {
+  public static Answer<RunQueryResponse> queryResponseWithDone(
+      boolean callWithoutOnComplete, String... documentNames) {
     RunQueryResponse[] responses = new RunQueryResponse[documentNames.length];
 
     for (int i = 0; i < documentNames.length; ++i) {
@@ -321,13 +322,16 @@ public final class LocalFirestoreHelper {
           Document.newBuilder().setName(documentNames[i]).putAllFields(SINGLE_FIELD_PROTO));
       runQueryResponse.setReadTime(
           com.google.protobuf.Timestamp.newBuilder().setSeconds(1).setNanos(2));
-      if (i == (documentNames.length - 1) && setDone) {
+      if (i == (documentNames.length - 1)) {
         runQueryResponse.setDone(true);
       }
       responses[i] = runQueryResponse.build();
     }
-
-    return streamingResponseWithoutOnComplete(responses);
+    if (callWithoutOnComplete) {
+      return streamingResponseWithoutOnComplete(responses);
+    } else {
+      return streamingResponse(responses, null);
+    }
   }
 
   /** Returns a stream of responses followed by an optional exception. */

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -955,7 +955,9 @@ public class QueryTest {
 
   @Test
   public void successfulReturnWithoutOnComplete() throws Exception {
-    doAnswer(queryResponseWithDone(true, DOCUMENT_NAME + "1", DOCUMENT_NAME + "2"))
+    doAnswer(
+            queryResponseWithDone(
+                /* callWithoutOnComplete */ true, DOCUMENT_NAME + "1", DOCUMENT_NAME + "2"))
         .when(firestoreMock)
         .streamRequest(
             runQuery.capture(),
@@ -992,7 +994,9 @@ public class QueryTest {
    * to true. The second time is when it receives half close
    */
   public void successfulReturnCallsOnCompleteTwice() throws Exception {
-    doAnswer(queryResponseWithDone(false, DOCUMENT_NAME + "1", DOCUMENT_NAME + "2"))
+    doAnswer(
+            queryResponseWithDone(
+                /* callWithoutOnComplete */ false, DOCUMENT_NAME + "1", DOCUMENT_NAME + "2"))
         .when(firestoreMock)
         .streamRequest(
             runQuery.capture(),
@@ -1001,6 +1005,7 @@ public class QueryTest {
 
     final Semaphore semaphore = new Semaphore(0);
     final Iterator<String> iterator = Arrays.asList("doc1", "doc2").iterator();
+    final int[] counter = {0};
 
     query.stream(
         new ApiStreamObserver<DocumentSnapshot>() {
@@ -1016,11 +1021,15 @@ public class QueryTest {
 
           @Override
           public void onCompleted() {
+            counter[0]++;
             semaphore.release();
           }
         });
 
     semaphore.acquire();
+
+    Thread.sleep(200);
+    assertEquals(1, counter[0]);
   }
 
   @Test

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -1028,6 +1028,7 @@ public class QueryTest {
 
     semaphore.acquire();
 
+    // Wait for some time to see whether onCompleted() has been called more than once
     Thread.sleep(200);
     assertEquals(1, counter[0]);
   }


### PR DESCRIPTION
Add logical termination for RunQueryResponse.

When the SDK side receives either halfClose or RunQueryResponse.done set to true, the SDK will return user requested documents.