### PR TITLE
samples: Add example snippets for stale reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.0.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.4')
 
 implementation 'com.google.cloud:google-cloud-firestore'
 ```
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-firestore:3.3.0'
+implementation 'com.google.cloud:google-cloud-firestore:3.7.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.3.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.7.0"
 ```
 
 ## Authentication

--- a/samples/snippets/src/main/java/com/example/firestore/snippets/ManageDataSnippets.java
+++ b/samples/snippets/src/main/java/com/example/firestore/snippets/ManageDataSnippets.java
@@ -516,7 +516,7 @@ class ManageDataSnippets {
               return documentResult;
             },
             options);
-    // [END firestore_firestore_snapshot_read]
+    // [END firestore_snapshot_read]
     return futureTransaction.get();
   }
 

--- a/samples/snippets/src/main/java/com/example/firestore/snippets/ManageDataSnippets.java
+++ b/samples/snippets/src/main/java/com/example/firestore/snippets/ManageDataSnippets.java
@@ -28,8 +28,6 @@ import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.SetOptions;
 import com.google.cloud.firestore.TransactionOptions;
-import com.google.cloud.firestore.TransactionOptions.ReadOnlyOptionsBuilder;
-import com.google.cloud.firestore.TransactionOptions.TransactionOptionsType;
 import com.google.cloud.firestore.WriteBatch;
 import com.google.cloud.firestore.WriteResult;
 import com.google.protobuf.Timestamp;
@@ -496,27 +494,24 @@ class ManageDataSnippets {
     // In the transaction options, Set read time and and set to read-only
     // Snapshot reads require read-only transactions
     // As an example, set read time to the update time of the previous write operation
-    final Timestamp readTime = com.google.protobuf.Timestamp.newBuilder()
-        .setSeconds(writeResult.getUpdateTime().getSeconds())
-        .setNanos(writeResult.getUpdateTime().getNanos())
-        .build();
-    // final Timestamp readTime = writeResult.getUpdateTime();
-    TransactionOptions options =
-        TransactionOptions.createReadOnlyOptionsBuilder()
-            .setReadTime(readTime)
+    final Timestamp readTime =
+        com.google.protobuf.Timestamp.newBuilder()
+            .setSeconds(writeResult.getUpdateTime().getSeconds())
+            .setNanos(writeResult.getUpdateTime().getNanos())
             .build();
+
+    TransactionOptions options =
+        TransactionOptions.createReadOnlyOptionsBuilder().setReadTime(readTime).build();
 
     // run a transaction
     ApiFuture<DocumentSnapshot> futureTransaction =
         db.runTransaction(
             transaction -> {
               // Execute a snapshot read document lookup
-              final DocumentSnapshot documentResult =
-                  transaction.get(documentReference).get();
+              final DocumentSnapshot documentResult = transaction.get(documentReference).get();
 
               // Execute a snapshot read query with the same transaction options
-              final QuerySnapshot queryResult =
-                  transaction.get(query).get();
+              final QuerySnapshot queryResult = transaction.get(query).get();
 
               return documentResult;
             },

--- a/samples/snippets/src/test/java/com/example/firestore/snippets/ManageDataSnippetsIT.java
+++ b/samples/snippets/src/test/java/com/example/firestore/snippets/ManageDataSnippetsIT.java
@@ -26,7 +26,6 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
-import com.google.protobuf.Timestamp;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;

--- a/samples/snippets/src/test/java/com/example/firestore/snippets/ManageDataSnippetsIT.java
+++ b/samples/snippets/src/test/java/com/example/firestore/snippets/ManageDataSnippetsIT.java
@@ -26,6 +26,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.protobuf.Timestamp;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
@@ -196,6 +197,14 @@ public class ManageDataSnippetsIT extends BaseIntegrationTest {
     final DocumentSnapshot data = documentReference.get().get();
     assertTrue(data.contains("population"));
     assertEquals((Long) 150L, data.getLong("population"));
+  }
+
+  @Test
+  public void testSnapshotReads() throws Exception {
+
+    DocumentSnapshot doc = manageDataSnippets.runSnapshotReads();
+    // Assert that population value is exactly the one from the write operation
+    assertEquals((Long) 860008L, doc.getLong("population"));
   }
 
   @AfterClass


### PR DESCRIPTION
As part of feature work for snapshot reads, add examples for the documentation.

Fixes #1002  ☕️
