### PR TITLE
fix: declare gson as runtime rather than test

### DIFF
--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -108,6 +108,11 @@
       <artifactId>google-cloud-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
     </dependency>
@@ -128,11 +133,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- Need testing utility classes for generated gRPC clients tests -->


### PR DESCRIPTION
Fixing similar issues as https://github.com/googleapis/java-pubsub/issues/1239.

In this case, declaring gson as test causes the flatten-maven-plugin to exclude gson from other dependency declarations.