### PR TITLE
feat: Query.count() implementation, part 1

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuery.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuery.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalExtensionOnly;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamController;
+import com.google.cloud.Timestamp;
+import com.google.firestore.v1.RunAggregationQueryRequest;
+import com.google.firestore.v1.RunAggregationQueryResponse;
+import com.google.firestore.v1.RunQueryRequest;
+import com.google.firestore.v1.StructuredAggregationQuery;
+import javax.annotation.Nonnull;
+
+@InternalExtensionOnly
+public class AggregateQuery {
+
+  /**
+   * The "alias" to specify in the {@link RunAggregationQueryRequest} proto when running a count
+   * query. The actual value is not meaningful, but will be used to get the count out of the {@link
+   * RunAggregationQueryResponse}.
+   */
+  private static final String ALIAS_COUNT = "count";
+
+  @Nonnull private final Query query;
+
+  AggregateQuery(@Nonnull Query query) {
+    this.query = query;
+  }
+
+  @Nonnull
+  public Query getQuery() {
+    return query;
+  }
+
+  @Nonnull
+  public ApiFuture<AggregateQuerySnapshot> get() {
+    RunAggregationQueryRequest request = toProto();
+    AggregateQueryResponseObserver responseObserver = new AggregateQueryResponseObserver();
+    ServerStreamingCallable<RunAggregationQueryRequest, RunAggregationQueryResponse> callable =
+        query.rpcContext.getClient().runAggregationQueryCallable();
+
+    query.rpcContext.streamRequest(request, responseObserver, callable);
+
+    return responseObserver.getFuture();
+  }
+
+  private final class AggregateQueryResponseObserver
+      implements ResponseObserver<RunAggregationQueryResponse> {
+
+    private final SettableApiFuture<AggregateQuerySnapshot> future = SettableApiFuture.create();
+
+    SettableApiFuture<AggregateQuerySnapshot> getFuture() {
+      return future;
+    }
+
+    @Override
+    public void onStart(StreamController streamController) {}
+
+    @Override
+    public void onResponse(RunAggregationQueryResponse response) {
+      Timestamp readTime = Timestamp.fromProto(response.getReadTime());
+      long count = response.getResult().getAggregateFieldsMap().get(ALIAS_COUNT).getIntegerValue();
+      future.set(new AggregateQuerySnapshot(AggregateQuery.this, readTime, count));
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      future.setException(throwable);
+    }
+
+    @Override
+    public void onComplete() {}
+  }
+
+  @Nonnull
+  public RunAggregationQueryRequest toProto() {
+    RunQueryRequest runQueryRequest = query.toProto();
+
+    RunAggregationQueryRequest.Builder request = RunAggregationQueryRequest.newBuilder();
+    request.setParent(runQueryRequest.getParent());
+
+    StructuredAggregationQuery.Builder structuredAggregationQuery =
+        request.getStructuredAggregationQueryBuilder();
+    structuredAggregationQuery.setStructuredQuery(runQueryRequest.getStructuredQuery());
+
+    StructuredAggregationQuery.Aggregation.Builder aggregation =
+        StructuredAggregationQuery.Aggregation.newBuilder();
+    aggregation.setCount(StructuredAggregationQuery.Aggregation.Count.getDefaultInstance());
+    aggregation.setAlias(ALIAS_COUNT);
+    structuredAggregationQuery.addAggregations(aggregation);
+
+    return request.build();
+  }
+
+  @Nonnull
+  public static AggregateQuery fromProto(Firestore firestore, RunAggregationQueryRequest proto) {
+    RunQueryRequest runQueryRequest =
+        RunQueryRequest.newBuilder()
+            .setParent(proto.getParent())
+            .setStructuredQuery(proto.getStructuredAggregationQuery().getStructuredQuery())
+            .build();
+    Query query = Query.fromProto(firestore, runQueryRequest);
+    return new AggregateQuery(query);
+  }
+
+  @Override
+  public int hashCode() {
+    return query.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    } else if (!(obj instanceof AggregateQuery)) {
+      return false;
+    }
+    AggregateQuery other = (AggregateQuery) obj;
+    return query.equals(other.query);
+  }
+}

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuerySnapshot.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuerySnapshot.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore;
+
+import com.google.api.core.InternalExtensionOnly;
+import com.google.cloud.Timestamp;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@InternalExtensionOnly
+public class AggregateQuerySnapshot {
+
+  @Nonnull private final AggregateQuery query;
+  @Nonnull private final Timestamp readTime;
+  private final long count;
+
+  AggregateQuerySnapshot(@Nonnull AggregateQuery query, @Nonnull Timestamp readTime, long count) {
+    this.query = query;
+    this.readTime = readTime;
+    this.count = count;
+  }
+
+  @Nonnull
+  public AggregateQuery getQuery() {
+    return query;
+  }
+
+  @Nonnull
+  public Timestamp getReadTime() {
+    return readTime;
+  }
+
+  @Nullable
+  public Long getCount() {
+    return count;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    } else if (!(obj instanceof AggregateQuerySnapshot)) {
+      return false;
+    }
+
+    AggregateQuerySnapshot other = (AggregateQuerySnapshot) obj;
+    return query.equals(other.query) && readTime.equals(other.readTime) && count == other.count;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(query, readTime, count);
+  }
+}

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
@@ -1846,6 +1846,11 @@ public class Query {
     return false;
   }
 
+  @Nonnull
+  public AggregateQuery count() {
+    return new AggregateQuery(this);
+  }
+
   /**
    * Returns true if this Query is equal to the provided object.
    *

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/spi/v1/FirestoreRpc.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/spi/v1/FirestoreRpc.java
@@ -37,6 +37,8 @@ import com.google.firestore.v1.ListenRequest;
 import com.google.firestore.v1.ListenResponse;
 import com.google.firestore.v1.PartitionQueryRequest;
 import com.google.firestore.v1.RollbackRequest;
+import com.google.firestore.v1.RunAggregationQueryRequest;
+import com.google.firestore.v1.RunAggregationQueryResponse;
 import com.google.firestore.v1.RunQueryRequest;
 import com.google.firestore.v1.RunQueryResponse;
 import com.google.protobuf.Empty;
@@ -59,6 +61,10 @@ public interface FirestoreRpc extends AutoCloseable, ServiceRpc {
 
   /** Runs a query. */
   ServerStreamingCallable<RunQueryRequest, RunQueryResponse> runQueryCallable();
+
+  /** Runs an aggregation query. */
+  ServerStreamingCallable<RunAggregationQueryRequest, RunAggregationQueryResponse>
+      runAggregationQueryCallable();
 
   /** Starts a new transaction. */
   UnaryCallable<BeginTransactionRequest, BeginTransactionResponse> beginTransactionCallable();

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/spi/v1/GrpcFirestoreRpc.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/spi/v1/GrpcFirestoreRpc.java
@@ -56,6 +56,8 @@ import com.google.firestore.v1.ListenRequest;
 import com.google.firestore.v1.ListenResponse;
 import com.google.firestore.v1.PartitionQueryRequest;
 import com.google.firestore.v1.RollbackRequest;
+import com.google.firestore.v1.RunAggregationQueryRequest;
+import com.google.firestore.v1.RunAggregationQueryResponse;
 import com.google.firestore.v1.RunQueryRequest;
 import com.google.firestore.v1.RunQueryResponse;
 import com.google.protobuf.Empty;
@@ -206,6 +208,12 @@ public class GrpcFirestoreRpc implements FirestoreRpc {
   @Override
   public ServerStreamingCallable<RunQueryRequest, RunQueryResponse> runQueryCallable() {
     return firestoreStub.runQueryCallable();
+  }
+
+  @Override
+  public ServerStreamingCallable<RunAggregationQueryRequest, RunAggregationQueryResponse>
+      runAggregationQueryCallable() {
+    return firestoreStub.runAggregationQueryCallable();
   }
 
   @Override

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/AggregateQuerySnapshotTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/AggregateQuerySnapshotTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.Timestamp;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AggregateQuerySnapshotTest {
+
+  @Mock private Query mockQuery;
+  @Mock private Query mockQuery2;
+
+  private AggregateQuery sampleAggregateQuery;
+  private AggregateQuery sampleAggregateQuery2;
+  private Timestamp sampleTimestamp;
+  private Timestamp sampleTimestamp2;
+
+  @Before
+  public void initializeSampleObjects() {
+    sampleAggregateQuery = new AggregateQuery(mockQuery);
+    sampleAggregateQuery2 = new AggregateQuery(mockQuery2);
+    sampleTimestamp = Timestamp.ofTimeSecondsAndNanos(42, 42);
+    sampleTimestamp2 = Timestamp.ofTimeSecondsAndNanos(24, 24);
+  }
+
+  @Test
+  public void getQueryShouldReturnTheAggregateQuerySpecifiedToTheConstructor() {
+    AggregateQuerySnapshot snapshot =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    assertThat(snapshot.getQuery()).isSameInstanceAs(sampleAggregateQuery);
+  }
+
+  @Test
+  public void getReadTimeShouldReturnTheTimestampSpecifiedToTheConstructor() {
+    AggregateQuerySnapshot snapshot =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    assertThat(snapshot.getReadTime()).isSameInstanceAs(sampleTimestamp);
+  }
+
+  @Test
+  public void getCountShouldReturnTheCountSpecifiedToTheConstructor() {
+    AggregateQuerySnapshot snapshot =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    assertThat(snapshot.getCount()).isEqualTo(42);
+  }
+
+  @Test
+  public void hashCodeShouldReturnSameHashCodeWhenConstructedWithSameObjects() {
+    AggregateQuerySnapshot snapshot1 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    AggregateQuerySnapshot snapshot2 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    assertThat(snapshot1.hashCode()).isEqualTo(snapshot2.hashCode());
+  }
+
+  @Test
+  public void hashCodeShouldReturnDifferentHashCodeWhenConstructedDifferentAggregateQuery() {
+    AggregateQuerySnapshot snapshot1 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    AggregateQuerySnapshot snapshot2 =
+        new AggregateQuerySnapshot(sampleAggregateQuery2, sampleTimestamp, 42);
+    assertThat(snapshot1.hashCode()).isNotEqualTo(snapshot2.hashCode());
+  }
+
+  @Test
+  public void hashCodeShouldReturnDifferentHashCodeWhenConstructedDifferentTimestamp() {
+    AggregateQuerySnapshot snapshot1 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    AggregateQuerySnapshot snapshot2 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp2, 42);
+    assertThat(snapshot1.hashCode()).isNotEqualTo(snapshot2.hashCode());
+  }
+
+  @Test
+  public void hashCodeShouldReturnDifferentHashCodeWhenConstructedDifferentCount() {
+    AggregateQuerySnapshot snapshot1 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    AggregateQuerySnapshot snapshot2 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 24);
+    assertThat(snapshot1.hashCode()).isNotEqualTo(snapshot2.hashCode());
+  }
+
+  @Test
+  public void equalsShouldReturnFalseWhenGivenNull() {
+    AggregateQuerySnapshot snapshot =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    assertThat(snapshot.equals(null)).isFalse();
+  }
+
+  @Test
+  public void equalsShouldReturnFalseWhenGivenADifferentObject() {
+    AggregateQuerySnapshot snapshot =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    assertThat(snapshot.equals("Not An AggregateQuerySnapshot")).isFalse();
+  }
+
+  @Test
+  public void equalsShouldReturnFalseWhenGivenAnAggregateQuerySnapshotWithADifferentQuery() {
+    AggregateQuerySnapshot snapshot1 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    AggregateQuerySnapshot snapshot2 =
+        new AggregateQuerySnapshot(sampleAggregateQuery2, sampleTimestamp, 42);
+    assertThat(snapshot1.equals(snapshot2)).isFalse();
+  }
+
+  @Test
+  public void equalsShouldReturnFalseWhenGivenAnAggregateQuerySnapshotWithADifferentReadTime() {
+    AggregateQuerySnapshot snapshot1 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    AggregateQuerySnapshot snapshot2 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp2, 42);
+    assertThat(snapshot1.equals(snapshot2)).isFalse();
+  }
+
+  @Test
+  public void equalsShouldReturnFalseWhenGivenAnAggregateQuerySnapshotWithADifferentCount() {
+    AggregateQuerySnapshot snapshot1 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    AggregateQuerySnapshot snapshot2 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 24);
+    assertThat(snapshot1.equals(snapshot2)).isFalse();
+  }
+
+  @Test
+  public void equalsShouldReturnTrueWhenGivenTheSameAggregateQuerySnapshotInstance() {
+    AggregateQuerySnapshot snapshot =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    assertThat(snapshot.equals(snapshot)).isTrue();
+  }
+
+  @Test
+  public void
+      equalsShouldReturnTrueWhenGivenAnAggregateQuerySnapshotConstructedWithTheSameArguments() {
+    AggregateQuerySnapshot snapshot1 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    AggregateQuerySnapshot snapshot2 =
+        new AggregateQuerySnapshot(sampleAggregateQuery, sampleTimestamp, 42);
+    assertThat(snapshot1.equals(snapshot2)).isTrue();
+  }
+}

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/AggregateQueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/AggregateQueryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AggregateQueryTest {
+
+  @Mock private Query mockQuery;
+  @Mock private Query mockQuery2;
+
+  @Test
+  public void getQueryShouldReturnTheQuerySpecifiedToTheConstructor() {
+    AggregateQuery aggregateQuery = new AggregateQuery(mockQuery);
+    assertThat(aggregateQuery.getQuery()).isSameInstanceAs(mockQuery);
+  }
+
+  @Test
+  public void hashCodeShouldReturnHashCodeOfUnderlyingQuery() {
+    AggregateQuery aggregateQuery = new AggregateQuery(mockQuery);
+    assertThat(aggregateQuery.hashCode()).isEqualTo(mockQuery.hashCode());
+  }
+
+  @Test
+  public void equalsShouldReturnFalseWhenGivenNull() {
+    AggregateQuery aggregateQuery = new AggregateQuery(mockQuery);
+    assertThat(aggregateQuery.equals(null)).isFalse();
+  }
+
+  @Test
+  public void equalsShouldReturnFalseWhenGivenADifferentObject() {
+    AggregateQuery aggregateQuery = new AggregateQuery(mockQuery);
+    assertThat(aggregateQuery.equals("Not An AggregateQuery")).isFalse();
+  }
+
+  @Test
+  public void equalsShouldReturnFalseWhenGivenAnAggregateQueryWithADifferentQuery() {
+    AggregateQuery aggregateQuery1 = new AggregateQuery(mockQuery);
+    AggregateQuery aggregateQuery2 = new AggregateQuery(mockQuery2);
+    assertThat(aggregateQuery1.equals(aggregateQuery2)).isFalse();
+  }
+
+  @Test
+  public void equalsShouldReturnTrueWhenGivenTheSameAggregateQueryInstance() {
+    AggregateQuery aggregateQuery = new AggregateQuery(mockQuery);
+    assertThat(aggregateQuery.equals(aggregateQuery)).isTrue();
+  }
+
+  @Test
+  public void equalsShouldReturnTrueWhenGivenAnAggregateQueryWithTheSameQuery() {
+    AggregateQuery aggregateQuery1 = new AggregateQuery(mockQuery);
+    AggregateQuery aggregateQuery2 = new AggregateQuery(mockQuery);
+    assertThat(aggregateQuery1.equals(aggregateQuery2)).isTrue();
+  }
+}

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITAggregateQueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITAggregateQueryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore.it;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.firestore.AggregateQuery;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.firestore.Query;
+import com.google.common.base.Preconditions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ITAggregateQueryTest {
+
+  private Firestore firestore;
+
+  @Before
+  public void setUpFirestore() {
+    // TODO(dconeybe) Remove the hardcoded "host" and "projectId" once COUNT is supported by prod.
+    firestore =
+        FirestoreOptions.newBuilder()
+            .setHost("localhost:8080")
+            .setProjectId("my-cool-project")
+            .build()
+            .getService();
+    Preconditions.checkNotNull(
+        firestore,
+        "Error instantiating Firestore. Check that the service account credentials were properly set.");
+  }
+
+  @After
+  public void tearDownFirestore() throws Exception {
+    if (firestore != null) {
+      firestore.close();
+      firestore = null;
+    }
+  }
+
+  @Test
+  public void toProtoFromProtoRoundTripShouldProduceEqualAggregateQueryObjects() {
+    Query query1 = firestore.collection("abc");
+    Query query2 = firestore.collection("def").whereEqualTo("age", 42).limit(5000).orderBy("name");
+    AggregateQuery countQuery1 = query1.count();
+    AggregateQuery countQuery2 = query2.count();
+    AggregateQuery countQuery1Recreated =
+        AggregateQuery.fromProto(firestore, countQuery1.toProto());
+    AggregateQuery countQuery2Recreated =
+        AggregateQuery.fromProto(firestore, countQuery2.toProto());
+    assertThat(countQuery1).isNotSameInstanceAs(countQuery1Recreated);
+    assertThat(countQuery2).isNotSameInstanceAs(countQuery2Recreated);
+    assertThat(countQuery1).isEqualTo(countQuery1Recreated);
+    assertThat(countQuery2).isEqualTo(countQuery2Recreated);
+    assertThat(countQuery1).isNotEqualTo(countQuery2);
+  }
+}

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
@@ -197,7 +197,6 @@ public class ITQueryCountTest {
     long readTimeMs1 = msFromTimestamp(snapshot1.getReadTime());
     long readTimeMs2 = msFromTimestamp(snapshot2.getReadTime());
     assertThat(readTimeMs1).isLessThan(readTimeMs2);
-    assertThat(readTimeMs2 - readTimeMs1).isLessThan(500);
   }
 
   @Test

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore.it;
+
+import static com.google.cloud.firestore.LocalFirestoreHelper.autoId;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.AggregateQuery;
+import com.google.cloud.firestore.AggregateQuerySnapshot;
+import com.google.cloud.firestore.CollectionGroup;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.WriteBatch;
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ITQueryCountTest {
+
+  @Rule public TestName testName = new TestName();
+
+  private Firestore firestore;
+
+  @Before
+  public void setUpFirestore() {
+    // TODO(dconeybe) Remove the hardcoded "host" and "projectId" once COUNT is supported by prod.
+    firestore =
+        FirestoreOptions.newBuilder()
+            .setHost("localhost:8080")
+            .setProjectId("my-cool-project")
+            .build()
+            .getService();
+    Preconditions.checkNotNull(
+        firestore,
+        "Error instantiating Firestore. Check that the service account credentials were properly set.");
+  }
+
+  @After
+  public void tearDownFirestore() throws Exception {
+    if (firestore != null) {
+      firestore.close();
+      firestore = null;
+    }
+  }
+
+  @Test
+  public void countShouldReturnZeroForEmptyCollection() throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(0);
+    AggregateQuerySnapshot snapshot = collection.count().get().get();
+    assertThat(snapshot.getCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void countShouldReturnNumDocumentsInNonEmptyCollection() throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(5);
+    AggregateQuerySnapshot snapshot = collection.count().get().get();
+    assertThat(snapshot.getCount()).isEqualTo(5);
+  }
+
+  @Test
+  public void countShouldReturnNumMatchingDocuments() throws Exception {
+    CollectionReference collection = createEmptyCollection();
+    createDocumentsWithKeyValuePair(collection, 3, "key", 42);
+    createDocumentsWithKeyValuePair(collection, 5, "key", 24);
+    AggregateQuerySnapshot snapshot = collection.whereEqualTo("key", 42).count().get().get();
+    assertThat(snapshot.getCount()).isEqualTo(3);
+  }
+
+  @Test
+  public void countShouldRespectLimit() throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(5);
+    AggregateQuerySnapshot snapshot = collection.limit(2).count().get().get();
+    assertThat(snapshot.getCount()).isEqualTo(2);
+  }
+
+  @Test
+  public void countShouldRespectOffset() throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(5);
+    AggregateQuerySnapshot snapshot = collection.offset(2).count().get().get();
+    assertThat(snapshot.getCount()).isEqualTo(3);
+  }
+
+  @Test
+  public void countShouldRespectOrderBy() throws Exception {
+    CollectionReference collection = createEmptyCollection();
+    createDocumentsWithKeyValuePair(collection, 3, "key1", 42);
+    createDocumentsWithKeyValuePair(collection, 5, "key2", 24);
+    createDocumentsWithKeyValuePair(collection, 4, "key1", 99);
+    AggregateQuerySnapshot snapshot = collection.orderBy("key1").count().get().get();
+    // Note: A subtle side effect of order-by is that it filters out documents that do not have the
+    // order-by field.
+    assertThat(snapshot.getCount()).isEqualTo(7);
+  }
+
+  @Test
+  public void countShouldRespectStartAtAndEndAt() throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(10);
+    List<QueryDocumentSnapshot> documentSnapshots = collection.get().get().getDocuments();
+    AggregateQuerySnapshot snapshot =
+        collection
+            .startAt(documentSnapshots.get(2))
+            .endAt(documentSnapshots.get(7))
+            .count()
+            .get()
+            .get();
+    assertThat(snapshot.getCount()).isEqualTo(6);
+  }
+
+  @Test
+  public void countShouldReturnNumberOfDocumentsForCollectionGroups() throws Exception {
+    CollectionGroup collectionGroup = createCollectionGroupWithDocuments(13);
+    AggregateQuerySnapshot snapshot = collectionGroup.count().get().get();
+    assertThat(snapshot.getCount()).isEqualTo(13);
+  }
+
+  @Test
+  public void inFlightCountQueriesShouldCompleteSuccessfullyWhenFirestoreIsClosed()
+      throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(20);
+    ApiFuture<AggregateQuerySnapshot> task = collection.count().get();
+    collection.getFirestore().close();
+    assertThat(task.get().getCount()).isEqualTo(20);
+  }
+
+  @Test
+  public void inFlightCountQueriesShouldCompleteSuccessfullyWhenFirestoreIsShutDownGracefully()
+      throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(20);
+    ApiFuture<AggregateQuerySnapshot> task = collection.count().get();
+    collection.getFirestore().shutdown();
+    assertThat(task.get().getCount()).isEqualTo(20);
+  }
+
+  @Test
+  public void inFlightCountQueriesShouldRunToCompletionWhenFirestoreIsShutDownForcefully()
+      throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(20);
+    ApiFuture<AggregateQuerySnapshot> task = collection.count().get();
+    collection.getFirestore().shutdownNow();
+    await(task);
+  }
+
+  @Test
+  public void countQueriesShouldFailIfStartedOnAClosedFirestoreInstance() throws Exception {
+    CollectionReference collection = createEmptyCollection();
+    AggregateQuery aggregateQuery = collection.count();
+    collection.getFirestore().close();
+    assertThrows(IllegalStateException.class, aggregateQuery::get);
+  }
+
+  @Test
+  public void countQueriesShouldFailIfStartedOnAShutDownFirestoreInstance() throws Exception {
+    CollectionReference collection = createEmptyCollection();
+    AggregateQuery aggregateQuery = collection.count();
+    collection.getFirestore().shutdown();
+    assertThrows(IllegalStateException.class, aggregateQuery::get);
+  }
+
+  @Test
+  public void aggregateSnapshotShouldHaveReasonableReadTime() throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(5);
+    AggregateQuerySnapshot snapshot1 = collection.count().get().get();
+    AggregateQuerySnapshot snapshot2 = collection.count().get().get();
+    long readTimeMs1 = msFromTimestamp(snapshot1.getReadTime());
+    long readTimeMs2 = msFromTimestamp(snapshot2.getReadTime());
+    assertThat(readTimeMs1).isLessThan(readTimeMs2);
+    assertThat(readTimeMs2 - readTimeMs1).isLessThan(500);
+  }
+
+  @Test
+  public void aggregateSnapshotShouldHaveCorrectQuery() throws Exception {
+    CollectionReference collection = createCollectionWithDocuments(5);
+    AggregateQuery aggregateQuery = collection.count();
+    AggregateQuerySnapshot snapshot1 = aggregateQuery.get().get();
+    AggregateQuerySnapshot snapshot2 = aggregateQuery.get().get();
+    assertThat(snapshot1.getQuery()).isSameInstanceAs(aggregateQuery);
+    assertThat(snapshot2.getQuery()).isSameInstanceAs(aggregateQuery);
+  }
+
+  @Test
+  public void aggregateQueryShouldHaveCorrectQuery() {
+    CollectionReference collection = firestore.collection("abc");
+    AggregateQuery aggregateQuery = collection.count();
+    assertThat(aggregateQuery.getQuery()).isSameInstanceAs(collection);
+  }
+
+  private CollectionReference createEmptyCollection() {
+    String collectionPath = "java-" + testName.getMethodName() + "-" + autoId();
+    return firestore.collection(collectionPath);
+  }
+
+  private CollectionReference createCollectionWithDocuments(int numDocuments)
+      throws ExecutionException, InterruptedException {
+    CollectionReference collection = createEmptyCollection();
+    createDocumentsWithKeyValuePair(collection, numDocuments, "key", 42);
+    return collection;
+  }
+
+  private void createDocumentsWithKeyValuePair(
+      CollectionReference collection, int numDocumentsToCreate, String key, int value)
+      throws ExecutionException, InterruptedException {
+    WriteBatch writeBatch = firestore.batch();
+    for (int i = 0; i < numDocumentsToCreate; i++) {
+      DocumentReference doc = collection.document();
+      writeBatch.create(doc, singletonMap(key, value));
+    }
+    writeBatch.commit().get();
+  }
+
+  private void createDocumentInCollection(WriteBatch writeBatch, CollectionReference collection)
+      throws ExecutionException, InterruptedException {
+    createDocumentInCollection(writeBatch, collection, "age", 42);
+  }
+
+  private void createDocumentInCollection(
+      WriteBatch writeBatch, CollectionReference collection, String key, int value)
+      throws ExecutionException, InterruptedException {
+    DocumentReference doc = collection.document();
+    writeBatch.create(doc, singletonMap(key, value));
+  }
+
+  private CollectionGroup createCollectionGroupWithDocuments(int numDocumentsToCreate)
+      throws ExecutionException, InterruptedException {
+    String collectionId = autoId();
+
+    // Create some collections to participate in the group.
+    ArrayList<CollectionReference> collections = new ArrayList<>();
+    for (int i = 0; i <= numDocumentsToCreate / 3; i++) {
+      collections.add(createEmptyCollection().document().collection(collectionId));
+    }
+
+    // Populate the collections with documents.
+    WriteBatch writeBatch = firestore.batch();
+    Iterator<CollectionReference> collectionIterator = loopInfinitely(collections);
+    for (int i = 0; i < numDocumentsToCreate; i++) {
+      createDocumentInCollection(writeBatch, collectionIterator.next());
+    }
+
+    writeBatch.commit().get();
+
+    return firestore.collectionGroup(collectionId);
+  }
+
+  /** Converts a {@link Timestamp} to the equivalent number of milliseconds. */
+  private static long msFromTimestamp(Timestamp timestamp) {
+    return (timestamp.getSeconds() * 1_000) + (timestamp.getNanos() / 1_000_000);
+  }
+
+  /**
+   * Creates and returns an infinite iterator that iterates over the given collection in the same
+   * order as its {@link Collection#iterator} method does, looping around back to the beginning when
+   * it reaches the end.
+   */
+  private static <T> Iterator<T> loopInfinitely(Collection<T> collection) {
+    return new Iterator<T>() {
+      private Iterator<T> it = collection.iterator();
+
+      @Override
+      public boolean hasNext() {
+        // NOTE: it.hasNext() will ALWAYS return true, except in the case that the given collection
+        // is empty.
+        return it.hasNext();
+      }
+
+      @Override
+      public T next() {
+        T element = it.next();
+        // If we've reached the end of the iterator, create a new one.
+        if (!it.hasNext()) {
+          it = collection.iterator();
+        }
+        return element;
+      }
+    };
+  }
+
+  /**
+   * Blocks the calling thread until the given future completes. Note that this method does not
+   * check the success or failure of the future; it returns regardless of its success or failure.
+   */
+  private static void await(ApiFuture<?> future) throws InterruptedException {
+    AtomicBoolean done = new AtomicBoolean(false);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    future.addListener(
+        () -> {
+          synchronized (done) {
+            done.set(true);
+            done.notifyAll();
+          }
+        },
+        executor);
+
+    synchronized (done) {
+      while (!done.get()) {
+        done.wait();
+      }
+    }
+
+    executor.shutdown();
+  }
+}

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
@@ -34,8 +34,6 @@ import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.WriteBatch;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
@@ -266,9 +266,9 @@ public class ITQueryCountTest {
 
     // Populate the collections with documents.
     WriteBatch writeBatch = firestore.batch();
-    Iterator<CollectionReference> collectionIterator = loopInfinitely(collections);
     for (int i = 0; i < numDocumentsToCreate; i++) {
-      createDocumentInCollection(writeBatch, collectionIterator.next());
+      CollectionReference collection = collections.get(i % collections.size());
+      createDocumentInCollection(writeBatch, collection);
     }
 
     writeBatch.commit().get();
@@ -279,34 +279,6 @@ public class ITQueryCountTest {
   /** Converts a {@link Timestamp} to the equivalent number of milliseconds. */
   private static long msFromTimestamp(Timestamp timestamp) {
     return (timestamp.getSeconds() * 1_000) + (timestamp.getNanos() / 1_000_000);
-  }
-
-  /**
-   * Creates and returns an infinite iterator that iterates over the given collection in the same
-   * order as its {@link Collection#iterator} method does, looping around back to the beginning when
-   * it reaches the end.
-   */
-  private static <T> Iterator<T> loopInfinitely(Collection<T> collection) {
-    return new Iterator<T>() {
-      private Iterator<T> it = collection.iterator();
-
-      @Override
-      public boolean hasNext() {
-        // NOTE: it.hasNext() will ALWAYS return true, except in the case that the given collection
-        // is empty.
-        return it.hasNext();
-      }
-
-      @Override
-      public T next() {
-        T element = it.next();
-        // If we've reached the end of the iterator, create a new one.
-        if (!it.hasNext()) {
-          it = collection.iterator();
-        }
-        return element;
-      }
-    };
   }
 
   /**


### PR DESCRIPTION
Initial implementation of server-side query result set counting.

This initial implementation is still missing some work, which will be done in follow-up PRs:
- transaction support (i.e. `Transaction.getCount()`)
- tracing support (i.e. `Tracing.getTracer()`)