### PR TITLE
docs: AggregateQuery.java: describe why we ignore subsequent responses

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuery.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuery.java
@@ -90,6 +90,10 @@ class AggregateQuery {
 
     @Override
     public void onResponse(RunAggregationQueryResponse response) {
+      // Ignore subsequent response messages. The RunAggregationQuery RPC returns a stream of
+      // responses (rather than just a single response); however, only the first response of the
+      // stream is actually used. Any more responses are technically errors, but since the Future
+      // will have already been notified, we just drop any unexpected responses.
       if (!isFutureNotified.compareAndSet(false, true)) {
         return;
       }


### PR DESCRIPTION
This is a follow-up from a comment in a previous PR: https://github.com/googleapis/java-firestore/pull/1033#discussion_r976892058