### PR TITLE
feat: Make count queries publicly available for use

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuery.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuery.java
@@ -33,9 +33,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-// TODO(count) Make this class public
 @InternalExtensionOnly
-class AggregateQuery {
+public class AggregateQuery {
 
   /**
    * The "alias" to specify in the {@link RunAggregationQueryRequest} proto when running a count

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuerySnapshot.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/AggregateQuerySnapshot.java
@@ -21,9 +21,8 @@ import com.google.cloud.Timestamp;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
-// TODO(count) Make this class public
 @InternalExtensionOnly
-class AggregateQuerySnapshot {
+public class AggregateQuerySnapshot {
 
   @Nonnull private final AggregateQuery query;
   @Nonnull private final Timestamp readTime;

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
@@ -1846,9 +1846,8 @@ public class Query {
     return false;
   }
 
-  // TODO(count) Make this method public
   @Nonnull
-  AggregateQuery count() {
+  public AggregateQuery count() {
     return new AggregateQuery(this);
   }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -191,7 +191,6 @@ public final class Transaction extends UpdateBuilder<Transaction> {
     return query.get(transactionId);
   }
 
-  // TODO(count) Make this method public
   /**
    * Returns the result from the provided aggregate query. Holds a pessimistic lock on all accessed
    * documents.
@@ -199,7 +198,7 @@ public final class Transaction extends UpdateBuilder<Transaction> {
    * @return The result of the aggregation.
    */
   @Nonnull
-  ApiFuture<AggregateQuerySnapshot> get(@Nonnull AggregateQuery query) {
+  public ApiFuture<AggregateQuerySnapshot> get(@Nonnull AggregateQuery query) {
     Preconditions.checkState(isEmpty(), READ_BEFORE_WRITE_ERROR_MSG);
 
     return query.get(transactionId);

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
@@ -14,17 +14,28 @@
  * limitations under the License.
  */
 
-package com.google.cloud.firestore;
+package com.google.cloud.firestore.it;
 
 import static com.google.cloud.firestore.LocalFirestoreHelper.autoId;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.api.core.ApiFuture;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.AggregateQuery;
+import com.google.cloud.firestore.AggregateQuerySnapshot;
+import com.google.cloud.firestore.CollectionGroup;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.TransactionOptions;
+import com.google.cloud.firestore.WriteBatch;
+import com.google.cloud.firestore.WriteResult;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,27 +52,16 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-// TODO(count) Move this class back into the "it" subdirectory.
 @RunWith(JUnit4.class)
 public class ITQueryCountTest {
 
   @Rule public TestName testName = new TestName();
 
-  private FirestoreOptions firestoreOptions;
   private Firestore firestore;
 
   @Before
-  public void setUpFirestoreOptions() {
-    firestoreOptions = FirestoreOptions.newBuilder().build();
-    // TODO(count) Remove the assumeTrue() below once count queries are supported in prod.
-    assumeTrue(
-        "Count queries are only supported in the Firestore Emulator (for now)",
-        firestoreOptions.getHost().startsWith("localhost"));
-  }
-
-  @Before
   public void setUpFirestore() {
-    firestore = firestoreOptions.getService();
+    firestore = FirestoreOptions.newBuilder().build().getService();
     Preconditions.checkNotNull(
         firestore,
         "Error instantiating Firestore. Check that the service account credentials were properly set.");
@@ -286,9 +286,15 @@ public class ITQueryCountTest {
 
     Long transactionCount = transactionFuture.get();
 
-    // NOTE: Snapshot reads are not yet implemented in the Firestore emulator (b/220918135). As a
-    // result, this test will fail when run against the Firestore emulator because it will
-    // incorrectly ignore the read time and return the count of the documents at the current time.
+    // Put this assumption as close to the end of this method as possible, so that at least the code
+    // above can be _executed_, even if we end up skipping the assertThat() check below.
+    assumeFalse(
+        "Snapshot reads are not yet implemented in the Firestore emulator (b/220918135). "
+            + "As a result, this test will fail when run against the Firestore emulator "
+            + "because it will incorrectly ignore the read time and return the count "
+            + "of the documents at the current time.",
+        firestore.getOptions().getHost().startsWith("localhost:"));
+
     assertThat(transactionCount).isEqualTo(5);
   }
 


### PR DESCRIPTION
This PR changes the visibility of classes and methods that provide "count" queries from default to public, making them available for anyone to use. See #1033 for the implementation of COUNT queries.