### PR TITLE
ci: Re-enable test aggregateQueryInATransactionShouldLockTheCountedDocuments

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
@@ -20,7 +20,6 @@ import static com.google.cloud.firestore.LocalFirestoreHelper.autoId;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assume.assumeTrue;
 
 import com.google.api.core.ApiFuture;
 import com.google.auto.value.AutoValue;
@@ -216,11 +215,6 @@ public class ITQueryCountTest {
 
   @Test
   public void aggregateQueryInATransactionShouldLockTheCountedDocuments() throws Exception {
-    assumeTrue(
-        "Skip this test when running against production because "
-            + "it appears that production is failing to lock the counted documents b/248152832",
-        isRunningAgainstFirestoreEmulator());
-
     CollectionReference collection = createEmptyCollection();
     DocumentReference document = createDocumentInCollection(collection);
     CountDownLatch aggregateQueryExecutedSignal = new CountDownLatch(1);
@@ -392,11 +386,6 @@ public class ITQueryCountTest {
     }
 
     executor.shutdown();
-  }
-
-  /** Returns whether the tests are running against the Firestore emulator. */
-  private boolean isRunningAgainstFirestoreEmulator() {
-    return firestore.getOptions().getHost().startsWith("localhost:");
   }
 
   @AutoValue

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
@@ -20,6 +20,7 @@ import static com.google.cloud.firestore.LocalFirestoreHelper.autoId;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.api.core.ApiFuture;
 import com.google.auto.value.AutoValue;
@@ -215,6 +216,11 @@ public class ITQueryCountTest {
 
   @Test
   public void aggregateQueryInATransactionShouldLockTheCountedDocuments() throws Exception {
+    assumeTrue(
+        "Skip this test when running against production because "
+            + "it appears that production is failing to lock the counted documents b/248152832",
+        isRunningAgainstFirestoreEmulator());
+
     CollectionReference collection = createEmptyCollection();
     DocumentReference document = createDocumentInCollection(collection);
     CountDownLatch aggregateQueryExecutedSignal = new CountDownLatch(1);
@@ -386,6 +392,11 @@ public class ITQueryCountTest {
     }
 
     executor.shutdown();
+  }
+
+  /** Returns whether the tests are running against the Firestore emulator. */
+  private boolean isRunningAgainstFirestoreEmulator() {
+    return firestore.getOptions().getHost().startsWith("localhost:");
   }
 
   @AutoValue

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
@@ -47,21 +47,11 @@ public class ITQueryCountTest {
 
   @Rule public TestName testName = new TestName();
 
-  private FirestoreOptions firestoreOptions;
   private Firestore firestore;
 
   @Before
-  public void setUpFirestoreOptions() {
-    firestoreOptions = FirestoreOptions.newBuilder().build();
-    // TODO(count) Remove the assumeTrue() below once count queries are supported in prod.
-    assumeTrue(
-        "Count queries are only supported in the Firestore Emulator (for now)",
-        firestoreOptions.getHost().startsWith("localhost"));
-  }
-
-  @Before
   public void setUpFirestore() {
-    firestore = firestoreOptions.getService();
+    firestore = FirestoreOptions.newBuilder().build().getService();
     Preconditions.checkNotNull(
         firestore,
         "Error instantiating Firestore. Check that the service account credentials were properly set.");

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
@@ -20,7 +20,6 @@ import static com.google.cloud.firestore.LocalFirestoreHelper.autoId;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assume.assumeTrue;
 
 import com.google.api.core.ApiFuture;
 import com.google.auto.value.AutoValue;

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
@@ -35,8 +35,8 @@ import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.TransactionOptions;
 import com.google.cloud.firestore.WriteBatch;
-import com.google.cloud.firestore.WriteResult;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -234,44 +235,41 @@ public class ITQueryCountTest {
 
   @Test
   public void aggregateQueryInATransactionShouldLockTheCountedDocuments() throws Exception {
-    assumeTrue(
-        "Skip this test when running against production because "
-            + "it appears that production is failing to lock the counted documents b/248152832",
-        isRunningAgainstFirestoreEmulator());
+    CollectionReference collection = createCollectionWithDocuments(7).collection();
+    DocumentReference resultsDocument = createEmptyCollection().document();
 
-    CollectionReference collection = createEmptyCollection();
-    DocumentReference document = createDocumentInCollection(collection);
     CountDownLatch aggregateQueryExecutedSignal = new CountDownLatch(1);
     CountDownLatch transactionContinueSignal = new CountDownLatch(1);
+    AtomicInteger transactionInvokeCount = new AtomicInteger(0);
 
     ApiFuture<Object> transactionFuture =
         collection
             .getFirestore()
             .runTransaction(
                 t -> {
-                  t.get(collection.count()).get();
-                  aggregateQueryExecutedSignal.countDown();
-                  transactionContinueSignal.await();
+                  int invokeCount = transactionInvokeCount.getAndIncrement();
+                  long count = t.get(collection.count()).get().getCount();
+                  if (invokeCount == 0) {
+                    aggregateQueryExecutedSignal.countDown();
+                    transactionContinueSignal.await();
+                  }
+                  t.set(resultsDocument, ImmutableMap.of("count", count));
                   return null;
                 });
 
-    ExecutionException executionException;
     try {
       aggregateQueryExecutedSignal.await();
-      ApiFuture<WriteResult> documentSetTask = document.set(singletonMap("abc", "def"));
-      executionException = assertThrows(ExecutionException.class, documentSetTask::get);
+      // Add a document to the collection so the count retrieved in the transaction is stale.
+      collection.document().set(ImmutableMap.of("key", 42L)).get();
     } finally {
       transactionContinueSignal.countDown();
     }
 
-    assertThat(executionException)
-        .hasCauseThat()
-        .hasMessageThat()
-        .ignoringCase()
-        .contains("transaction lock timeout");
-
     // Wait for the transaction to finish.
     transactionFuture.get();
+
+    // Verify that the correct count was written in the transaction.
+    assertThat(resultsDocument.get().get().getLong("count")).isEqualTo(8);
   }
 
   @Test


### PR DESCRIPTION
The test `aggregateQueryInATransactionShouldLockTheCountedDocuments` was disabled in https://github.com/googleapis/java-firestore/pull/1040 because it failed when running against production.

```
java.lang.AssertionError: expected java.util.concurrent.ExecutionException to be thrown, but nothing was thrown
	at com.google.cloud.firestore.ITQueryCountTest.aggregateQueryInATransactionShouldLockTheCountedDocuments(ITQueryCountTest.java:238)
```

I need to check if this is a bug in the backend or a faulty test. This test passes against the Firestore emulator.

Here is the line in the test that is failing: https://github.com/googleapis/java-firestore/blob/a7e90ddaf770f3f4a67072688ddefc28a1928f5d/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java#L238

I've opened b/248152832 to investigate.

Once the issue is fixed, merge this PR to re-enable the test.