### PR TITLE
test: Skip aggregateQueryInATransactionShouldRespectReadTime when run against the emulator

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ITQueryCountTest.java
@@ -20,6 +20,7 @@ import static com.google.cloud.firestore.LocalFirestoreHelper.autoId;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.api.core.ApiFuture;
@@ -286,9 +287,15 @@ public class ITQueryCountTest {
 
     Long transactionCount = transactionFuture.get();
 
-    // NOTE: Snapshot reads are not yet implemented in the Firestore emulator (b/220918135). As a
-    // result, this test will fail when run against the Firestore emulator because it will
-    // incorrectly ignore the read time and return the count of the documents at the current time.
+    // Put this assumption as close to the end of this method as possible, so that at least the code
+    // above can be _executed_, even if we end up skipping the assertThat() check below.
+    assumeFalse(
+        "Snapshot reads are not yet implemented in the Firestore emulator (b/220918135). "
+            + "As a result, this test will fail when run against the Firestore emulator "
+            + "because it will incorrectly ignore the read time and return the count "
+            + "of the documents at the current time.",
+        isRunningAgainstFirestoreEmulator());
+
     assertThat(transactionCount).isEqualTo(5);
   }
 
@@ -397,6 +404,11 @@ public class ITQueryCountTest {
     }
 
     executor.shutdown();
+  }
+
+  /** Returns whether the tests are running against the Firestore emulator. */
+  private boolean isRunningAgainstFirestoreEmulator() {
+    return firestore.getOptions().getHost().startsWith("localhost:");
   }
 
   @AutoValue


### PR DESCRIPTION
The test aggregateQueryInATransactionShouldRespectReadTime fails when run against the Firestore emulator due to a known issue: b/220918135 (When creating a new read-only or read-write transaction, the Firestore emulator creates the transaction at the current time regardless of the user's specified TransactionsOptions. In the case of read-only transaction, if the user specifies the read_time, that will not be honoured. If the user specifies a retry_transaction, that will not be honored).

Instead of letting the test fail, this PR has it be skipped with an appropriate error message.