### PR TITLE
feat: Add retry logic to COUNT queries

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryCountTest.java
@@ -30,7 +30,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
+import com.google.api.core.ApiClock;
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
@@ -39,14 +41,15 @@ import com.google.cloud.firestore.spi.v1.FirestoreRpc;
 import com.google.firestore.v1.RunAggregationQueryRequest;
 import com.google.firestore.v1.RunAggregationQueryResponse;
 import com.google.firestore.v1.StructuredQuery;
+import io.grpc.Status;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Matchers;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.threeten.bp.Duration;
@@ -58,7 +61,7 @@ public class QueryCountTest {
   private final FirestoreImpl firestoreMock =
       new FirestoreImpl(
           FirestoreOptions.newBuilder().setProjectId("test-project").build(),
-          Mockito.mock(FirestoreRpc.class));
+          mock(FirestoreRpc.class));
 
   @Captor private ArgumentCaptor<RunAggregationQueryRequest> runAggregationQuery;
 
@@ -211,6 +214,117 @@ public class QueryCountTest {
 
     AggregateQuery aggregateQuery = query.count();
     AggregateQuerySnapshot snapshot = aggregateQuery.get().get();
+
     assertThat(snapshot.getQuery()).isSameInstanceAs(aggregateQuery);
   }
+
+  @Test
+  public void shouldNotRetryIfExceptionIsNotFirestoreException() {
+    doAnswer(aggregationQueryResponse(new NotFirestoreException()))
+        .doAnswer(aggregationQueryResponse())
+        .when(firestoreMock)
+        .streamRequest(
+            runAggregationQuery.capture(),
+            streamObserverCapture.capture(),
+            Matchers.<ServerStreamingCallable>any());
+
+    ApiFuture<AggregateQuerySnapshot> future = query.count().get();
+
+    assertThrows(ExecutionException.class, future::get);
+  }
+
+  @Test
+  public void shouldRetryIfExceptionIsFirestoreExceptionWithRetryableStatus() throws Exception {
+    doAnswer(aggregationQueryResponse(new FirestoreException("reason", Status.INTERNAL)))
+        .doAnswer(aggregationQueryResponse(42))
+        .when(firestoreMock)
+        .streamRequest(
+            runAggregationQuery.capture(),
+            streamObserverCapture.capture(),
+            Matchers.<ServerStreamingCallable>any());
+
+    ApiFuture<AggregateQuerySnapshot> future = query.count().get();
+    AggregateQuerySnapshot snapshot = future.get();
+
+    assertThat(snapshot.getCount()).isEqualTo(42);
+  }
+
+  @Test
+  public void shouldNotRetryIfExceptionIsFirestoreExceptionWithNonRetryableStatus() {
+    doReturn(Duration.ZERO).when(firestoreMock).getTotalRequestTimeout();
+    doAnswer(aggregationQueryResponse(new FirestoreException("reason", Status.INVALID_ARGUMENT)))
+        .doAnswer(aggregationQueryResponse())
+        .when(firestoreMock)
+        .streamRequest(
+            runAggregationQuery.capture(),
+            streamObserverCapture.capture(),
+            Matchers.<ServerStreamingCallable>any());
+
+    ApiFuture<AggregateQuerySnapshot> future = query.count().get();
+
+    assertThrows(ExecutionException.class, future::get);
+  }
+
+  @Test
+  public void
+      shouldRetryIfExceptionIsFirestoreExceptionWithRetryableStatusWithInfiniteTimeoutWindow()
+          throws Exception {
+    doReturn(Duration.ZERO).when(firestoreMock).getTotalRequestTimeout();
+    doAnswer(aggregationQueryResponse(new FirestoreException("reason", Status.INTERNAL)))
+        .doAnswer(aggregationQueryResponse(42))
+        .when(firestoreMock)
+        .streamRequest(
+            runAggregationQuery.capture(),
+            streamObserverCapture.capture(),
+            Matchers.<ServerStreamingCallable>any());
+
+    ApiFuture<AggregateQuerySnapshot> future = query.count().get();
+    AggregateQuerySnapshot snapshot = future.get();
+
+    assertThat(snapshot.getCount()).isEqualTo(42);
+  }
+
+  @Test
+  public void shouldRetryIfExceptionIsFirestoreExceptionWithRetryableStatusWithinTimeoutWindow()
+      throws Exception {
+    doReturn(Duration.ofDays(999)).when(firestoreMock).getTotalRequestTimeout();
+    doAnswer(aggregationQueryResponse(new FirestoreException("reason", Status.INTERNAL)))
+        .doAnswer(aggregationQueryResponse(42))
+        .when(firestoreMock)
+        .streamRequest(
+            runAggregationQuery.capture(),
+            streamObserverCapture.capture(),
+            Matchers.<ServerStreamingCallable>any());
+
+    ApiFuture<AggregateQuerySnapshot> future = query.count().get();
+    AggregateQuerySnapshot snapshot = future.get();
+
+    assertThat(snapshot.getCount()).isEqualTo(42);
+  }
+
+  @Test
+  public void
+      shouldNotRetryIfExceptionIsFirestoreExceptionWithRetryableStatusBeyondTimeoutWindow() {
+    ApiClock clockMock = mock(ApiClock.class);
+    doReturn(clockMock).when(firestoreMock).getClock();
+    doReturn(TimeUnit.SECONDS.toNanos(10))
+        .doReturn(TimeUnit.SECONDS.toNanos(20))
+        .doReturn(TimeUnit.SECONDS.toNanos(30))
+        .when(clockMock)
+        .nanoTime();
+    doReturn(Duration.ofSeconds(5)).when(firestoreMock).getTotalRequestTimeout();
+    doAnswer(aggregationQueryResponse(new FirestoreException("reason", Status.INTERNAL)))
+        .doAnswer(aggregationQueryResponse(42))
+        .when(firestoreMock)
+        .streamRequest(
+            runAggregationQuery.capture(),
+            streamObserverCapture.capture(),
+            Matchers.<ServerStreamingCallable>any());
+
+    ApiFuture<AggregateQuerySnapshot> future = query.count().get();
+
+    assertThrows(ExecutionException.class, future::get);
+  }
+
+  private static final class NotFirestoreException extends Exception {}
 }


### PR DESCRIPTION
When `AggregateQuery` was added by #1033 it failed to implement any "retry" logic. This PR adds in that retry logic, based heavily on the pre-existing retry logic from the `Query` class.