### PR TITLE
test: Fix distracting NPE from ExampleFirestoreWriteReadTest.tearDown()

### DIFF
--- a/samples/snippets/src/test/java/com/example/firestore/beam/ExampleFirestoreWriteReadTest.java
+++ b/samples/snippets/src/test/java/com/example/firestore/beam/ExampleFirestoreWriteReadTest.java
@@ -55,7 +55,9 @@ public class ExampleFirestoreWriteReadTest {
 
   @AfterClass
   public static void tearDown() {
-    deleteCollection(firestore.collection(collectionId), 1);
+    if (firestore != null && collectionId != null) {
+      deleteCollection(firestore.collection(collectionId), 1);
+    }
   }
 
   @Test


### PR DESCRIPTION
The `ExampleFirestoreWriteReadTest.tearDown()` method assumes that the static variables `firestore` and `collectionId` are not null; however, if `setUp()` failed with an exception, then these variables are null. In such a case, `tearDown()` throws a `NullPointerException`. This NPE is just added noise that distracts from the real issue, that `setUp()` failed. This PR fixes this noisy NPE by simply performing a null check before using these static variables.