### PR TITLE
chore: owlbot-java configuration

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -1,3 +1,5 @@
+docker:
+  image: "gcr.io/cloud-devrel-public-resources/owlbot-java:latest"
 
 deep-remove-regex:
 - "/grpc-google-.*/src"


### PR DESCRIPTION
With the field, this repository should receive the "owl-bot-update-lock" pull requests. This is a follow-up for https://github.com/googleapis/java-firestore/pull/1078#issuecomment-1290935777.