### PR TITLE
chore(java): restore release requirements file changes

### DIFF
--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -28,7 +28,7 @@ fi
 pushd $(dirname "$0")/../../
 
 # install docuploader package
-python3 -m pip install gcp-docuploader
+python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # compile all packages
 mvn clean install -B -q -DskipTests=true

--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -28,7 +28,7 @@ fi
 pushd $(dirname "$0")/../../
 
 # install docuploader package
-python3 -m pip install gcp-docuploader
+python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # compile all packages
 mvn clean install -B -q -DskipTests=true

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -16,7 +16,8 @@
 set -eo pipefail
 
 # Start the releasetool reporter
-python3 -m pip install gcp-releasetool
+requirementsFile=$(realpath $(dirname "${BASH_SOURCE[0]}")/../requirements.txt)
+python3 -m pip install --require-hashes -r $requirementsFile
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
 
 source $(dirname "$0")/common.sh

--- a/owlbot.py
+++ b/owlbot.py
@@ -85,5 +85,9 @@ java.common_templates(excludes=[
     '.kokoro/nightly/java11-integration.cfg',
     '.kokoro/nightly/samples.cfg',
     '.kokoro/build.sh',
-    'samples/snapshot/pom.xml'
+    'samples/snapshot/pom.xml',
+    '.kokoro/release/publish_javadoc.sh',
+    '.kokoro/release/publish_javadoc11.sh',
+    '.kokoro/release/stage.sh',
+    'renovate.json'
 ])

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
This PR also excludes release script from the owlbot post-processor script to prevent owlbot from making unexpected changes. For example: https://github.com/googleapis/java-firestore/pull/1092/
