### PR TITLE
chore: Exclude requirements.txt from OwlBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.6.0')
+implementation platform('com.google.cloud:libraries-bom:26.7.0')
 
 implementation 'com.google.cloud:google-cloud-firestore'
 ```

--- a/owlbot.py
+++ b/owlbot.py
@@ -90,5 +90,6 @@ java.common_templates(excludes=[
     '.kokoro/release/publish_javadoc.sh',
     '.kokoro/release/publish_javadoc11.sh',
     '.kokoro/release/stage.sh',
+    '.kokoro/requirements.txt',
     'renovate.json'
 ])


### PR DESCRIPTION
This is to fix PRs where OwlBot undoes updates.

See for example:
https://github.com/googleapis/java-firestore/pull/1189