### PR TITLE
chore(deps): update ghcr.io/graalvm/graalvm-ce docker tag to v22.3.2

### DIFF
--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
 }
 
 env_vars: {


### PR DESCRIPTION
Update was made in synthtool but wasn't propagated to firestore due to an [owlbot exclusion](https://github.com/googleapis/java-firestore/blob/be5008f3de969df37932f8d844c8206597a59c14/owlbot.py#L82-L83). 