### PR TITLE
fix: Remove  'x-goog-request-params' header from GRPC requests due to incorrect format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.18.0')
+implementation platform('com.google.cloud:libraries-bom:26.19.0')
 
 implementation 'com.google.cloud:google-cloud-firestore'
 ```

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/v1/stub/GrpcFirestoreStub.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/v1/stub/GrpcFirestoreStub.java
@@ -62,7 +62,10 @@ import com.google.protobuf.Empty;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
@@ -282,6 +285,10 @@ public class GrpcFirestoreStub extends FirestoreStub {
     this(settings, clientContext, new GrpcFirestoreCallableFactory());
   }
 
+  private Map<String, String> fixFormat(Map<String, String> old) {
+    return Collections.emptyMap();
+  }
+
   /**
    * Constructs an instance of GrpcFirestoreStub, using the given settings. This is protected so
    * that it is easy to make a subclass, but otherwise, the static factory methods should be
@@ -302,7 +309,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("name", String.valueOf(request.getName()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<ListDocumentsRequest, ListDocumentsResponse> listDocumentsTransportSettings =
@@ -313,7 +320,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("collection_id", String.valueOf(request.getCollectionId()));
                   params.put("parent", String.valueOf(request.getParent()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<UpdateDocumentRequest, Document> updateDocumentTransportSettings =
@@ -323,7 +330,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("document.name", String.valueOf(request.getDocument().getName()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<DeleteDocumentRequest, Empty> deleteDocumentTransportSettings =
@@ -333,7 +340,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("name", String.valueOf(request.getName()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<BatchGetDocumentsRequest, BatchGetDocumentsResponse>
@@ -344,7 +351,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                     request -> {
                       ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                       params.put("database", String.valueOf(request.getDatabase()));
-                      return params.build();
+                      return fixFormat(params.build());
                     })
                 .build();
     GrpcCallSettings<BeginTransactionRequest, BeginTransactionResponse>
@@ -355,7 +362,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                     request -> {
                       ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                       params.put("database", String.valueOf(request.getDatabase()));
-                      return params.build();
+                      return fixFormat(params.build());
                     })
                 .build();
     GrpcCallSettings<CommitRequest, CommitResponse> commitTransportSettings =
@@ -365,7 +372,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("database", String.valueOf(request.getDatabase()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<RollbackRequest, Empty> rollbackTransportSettings =
@@ -375,7 +382,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("database", String.valueOf(request.getDatabase()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<RunQueryRequest, RunQueryResponse> runQueryTransportSettings =
@@ -385,7 +392,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("parent", String.valueOf(request.getParent()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<RunAggregationQueryRequest, RunAggregationQueryResponse>
@@ -396,7 +403,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                     request -> {
                       ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                       params.put("parent", String.valueOf(request.getParent()));
-                      return params.build();
+                      return fixFormat(params.build());
                     })
                 .build();
     GrpcCallSettings<PartitionQueryRequest, PartitionQueryResponse>
@@ -407,7 +414,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                     request -> {
                       ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                       params.put("parent", String.valueOf(request.getParent()));
-                      return params.build();
+                      return fixFormat(params.build());
                     })
                 .build();
     GrpcCallSettings<WriteRequest, WriteResponse> writeTransportSettings =
@@ -417,7 +424,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("database", String.valueOf(request.getDatabase()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<ListenRequest, ListenResponse> listenTransportSettings =
@@ -427,7 +434,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("database", String.valueOf(request.getDatabase()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<ListCollectionIdsRequest, ListCollectionIdsResponse>
@@ -438,7 +445,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                     request -> {
                       ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                       params.put("parent", String.valueOf(request.getParent()));
-                      return params.build();
+                      return fixFormat(params.build());
                     })
                 .build();
     GrpcCallSettings<BatchWriteRequest, BatchWriteResponse> batchWriteTransportSettings =
@@ -448,7 +455,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                 request -> {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("database", String.valueOf(request.getDatabase()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
     GrpcCallSettings<CreateDocumentRequest, Document> createDocumentTransportSettings =
@@ -459,7 +466,7 @@ public class GrpcFirestoreStub extends FirestoreStub {
                   ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
                   params.put("collection_id", String.valueOf(request.getCollectionId()));
                   params.put("parent", String.valueOf(request.getParent()));
-                  return params.build();
+                  return fixFormat(params.build());
                 })
             .build();
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/v1/stub/GrpcFirestoreStub.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/v1/stub/GrpcFirestoreStub.java
@@ -65,6 +65,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
 
@@ -285,10 +287,6 @@ public class GrpcFirestoreStub extends FirestoreStub {
     this(settings, clientContext, new GrpcFirestoreCallableFactory());
   }
 
-  private Map<String, String> fixFormat(Map<String, String> old) {
-    return Collections.emptyMap();
-  }
-
   /**
    * Constructs an instance of GrpcFirestoreStub, using the given settings. This is protected so
    * that it is easy to make a subclass, but otherwise, the static factory methods should be
@@ -305,169 +303,71 @@ public class GrpcFirestoreStub extends FirestoreStub {
     GrpcCallSettings<GetDocumentRequest, Document> getDocumentTransportSettings =
         GrpcCallSettings.<GetDocumentRequest, Document>newBuilder()
             .setMethodDescriptor(getDocumentMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("name", String.valueOf(request.getName()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<ListDocumentsRequest, ListDocumentsResponse> listDocumentsTransportSettings =
         GrpcCallSettings.<ListDocumentsRequest, ListDocumentsResponse>newBuilder()
             .setMethodDescriptor(listDocumentsMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("collection_id", String.valueOf(request.getCollectionId()));
-                  params.put("parent", String.valueOf(request.getParent()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<UpdateDocumentRequest, Document> updateDocumentTransportSettings =
         GrpcCallSettings.<UpdateDocumentRequest, Document>newBuilder()
             .setMethodDescriptor(updateDocumentMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("document.name", String.valueOf(request.getDocument().getName()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<DeleteDocumentRequest, Empty> deleteDocumentTransportSettings =
         GrpcCallSettings.<DeleteDocumentRequest, Empty>newBuilder()
             .setMethodDescriptor(deleteDocumentMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("name", String.valueOf(request.getName()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<BatchGetDocumentsRequest, BatchGetDocumentsResponse>
         batchGetDocumentsTransportSettings =
             GrpcCallSettings.<BatchGetDocumentsRequest, BatchGetDocumentsResponse>newBuilder()
                 .setMethodDescriptor(batchGetDocumentsMethodDescriptor)
-                .setParamsExtractor(
-                    request -> {
-                      ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                      params.put("database", String.valueOf(request.getDatabase()));
-                      return fixFormat(params.build());
-                    })
                 .build();
     GrpcCallSettings<BeginTransactionRequest, BeginTransactionResponse>
         beginTransactionTransportSettings =
             GrpcCallSettings.<BeginTransactionRequest, BeginTransactionResponse>newBuilder()
                 .setMethodDescriptor(beginTransactionMethodDescriptor)
-                .setParamsExtractor(
-                    request -> {
-                      ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                      params.put("database", String.valueOf(request.getDatabase()));
-                      return fixFormat(params.build());
-                    })
                 .build();
     GrpcCallSettings<CommitRequest, CommitResponse> commitTransportSettings =
         GrpcCallSettings.<CommitRequest, CommitResponse>newBuilder()
             .setMethodDescriptor(commitMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("database", String.valueOf(request.getDatabase()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<RollbackRequest, Empty> rollbackTransportSettings =
         GrpcCallSettings.<RollbackRequest, Empty>newBuilder()
             .setMethodDescriptor(rollbackMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("database", String.valueOf(request.getDatabase()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<RunQueryRequest, RunQueryResponse> runQueryTransportSettings =
         GrpcCallSettings.<RunQueryRequest, RunQueryResponse>newBuilder()
             .setMethodDescriptor(runQueryMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("parent", String.valueOf(request.getParent()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<RunAggregationQueryRequest, RunAggregationQueryResponse>
         runAggregationQueryTransportSettings =
             GrpcCallSettings.<RunAggregationQueryRequest, RunAggregationQueryResponse>newBuilder()
                 .setMethodDescriptor(runAggregationQueryMethodDescriptor)
-                .setParamsExtractor(
-                    request -> {
-                      ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                      params.put("parent", String.valueOf(request.getParent()));
-                      return fixFormat(params.build());
-                    })
                 .build();
     GrpcCallSettings<PartitionQueryRequest, PartitionQueryResponse>
         partitionQueryTransportSettings =
             GrpcCallSettings.<PartitionQueryRequest, PartitionQueryResponse>newBuilder()
                 .setMethodDescriptor(partitionQueryMethodDescriptor)
-                .setParamsExtractor(
-                    request -> {
-                      ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                      params.put("parent", String.valueOf(request.getParent()));
-                      return fixFormat(params.build());
-                    })
                 .build();
     GrpcCallSettings<WriteRequest, WriteResponse> writeTransportSettings =
         GrpcCallSettings.<WriteRequest, WriteResponse>newBuilder()
             .setMethodDescriptor(writeMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("database", String.valueOf(request.getDatabase()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<ListenRequest, ListenResponse> listenTransportSettings =
         GrpcCallSettings.<ListenRequest, ListenResponse>newBuilder()
             .setMethodDescriptor(listenMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("database", String.valueOf(request.getDatabase()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<ListCollectionIdsRequest, ListCollectionIdsResponse>
         listCollectionIdsTransportSettings =
             GrpcCallSettings.<ListCollectionIdsRequest, ListCollectionIdsResponse>newBuilder()
                 .setMethodDescriptor(listCollectionIdsMethodDescriptor)
-                .setParamsExtractor(
-                    request -> {
-                      ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                      params.put("parent", String.valueOf(request.getParent()));
-                      return fixFormat(params.build());
-                    })
                 .build();
     GrpcCallSettings<BatchWriteRequest, BatchWriteResponse> batchWriteTransportSettings =
         GrpcCallSettings.<BatchWriteRequest, BatchWriteResponse>newBuilder()
             .setMethodDescriptor(batchWriteMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("database", String.valueOf(request.getDatabase()));
-                  return fixFormat(params.build());
-                })
             .build();
     GrpcCallSettings<CreateDocumentRequest, Document> createDocumentTransportSettings =
         GrpcCallSettings.<CreateDocumentRequest, Document>newBuilder()
             .setMethodDescriptor(createDocumentMethodDescriptor)
-            .setParamsExtractor(
-                request -> {
-                  ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                  params.put("collection_id", String.valueOf(request.getCollectionId()));
-                  params.put("parent", String.valueOf(request.getParent()));
-                  return fixFormat(params.build());
-                })
             .build();
 
     this.getDocumentCallable =

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/v1/stub/GrpcFirestoreStub.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/v1/stub/GrpcFirestoreStub.java
@@ -28,7 +28,6 @@ import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.common.collect.ImmutableMap;
 import com.google.firestore.v1.BatchGetDocumentsRequest;
 import com.google.firestore.v1.BatchGetDocumentsResponse;
 import com.google.firestore.v1.BatchWriteRequest;
@@ -62,12 +61,7 @@ import com.google.protobuf.Empty;
 import io.grpc.MethodDescriptor;
 import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.


### PR DESCRIPTION
Remove 'x-goog-request-params' from headers, and fallback on `google-cloud-resource-prefix` instead.