### PR TITLE
Check orderBy clause when display warning for DocumentReference in cursor

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Query.java
@@ -1287,7 +1287,9 @@ public class Query {
   }
 
   private void warningOnSingleDocumentReference(Object... fieldValues) {
-    if (fieldValues.length == 1 && fieldValues[0] instanceof DocumentReference) {
+    if (options.getFieldOrders().isEmpty()
+        && fieldValues.length == 1
+        && fieldValues[0] instanceof DocumentReference) {
       LOGGER.warning(
           "Warning: Passing DocumentReference into a cursor without orderBy clause is not an intended "
               + "behavior. Please use DocumentSnapshot or add an explicit orderBy on document key field.");

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -615,6 +615,23 @@ public class QueryTest {
   }
 
   @Test
+  public void withDocumentIdAndDocumentReferenceCursor() {
+    doAnswer(queryResponse())
+        .when(firestoreMock)
+        .streamRequest(runQuery.capture(), streamObserverCapture.capture(), any());
+
+    DocumentReference documentCursor = firestoreMock.document(DOCUMENT_PATH);
+    Value documentValue = reference(DOCUMENT_NAME);
+
+    query.orderBy(FieldPath.documentId()).startAt(documentCursor).get();
+
+    RunQueryRequest queryRequest =
+        query(order("__name__", StructuredQuery.Direction.ASCENDING), startAt(documentValue, true));
+
+    assertEquals(queryRequest, runQuery.getValue());
+  }
+
+  @Test
   public void withExtractedDirectionForDocumentSnapshotCursor() {
     doAnswer(queryResponse())
         .when(firestoreMock)


### PR DESCRIPTION
Patch on this fix:https://github.com/googleapis/java-firestore/pull/1397 
The warning message should display if user is passing in a single DocumentReference into a cursor, but didn't add an orderBy clause.