### PR TITLE
build: do not declare javadoc plugin version

### DIFF
--- a/google-cloud-firestore-admin/pom.xml
+++ b/google-cloud-firestore-admin/pom.xml
@@ -109,7 +109,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <configuration>
           <show>protected</show>
           <nohelp>true</nohelp>

--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -180,7 +180,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <configuration>
           <show>protected</show>
           <nohelp>true</nohelp>

--- a/grpc-google-cloud-firestore-admin-v1/pom.xml
+++ b/grpc-google-cloud-firestore-admin-v1/pom.xml
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.6.0</version>
                 <configuration>
                     <show>protected</show>
                     <nohelp>true</nohelp>

--- a/grpc-google-cloud-firestore-v1/pom.xml
+++ b/grpc-google-cloud-firestore-v1/pom.xml
@@ -46,7 +46,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.6.0</version>
                 <configuration>
                     <show>protected</show>
                     <nohelp>true</nohelp>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,6 @@
     <plugin>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-javadoc-plugin</artifactId>
-      <version>3.6.0</version>
       <reportSets>
         <reportSet>
           <id>html</id>


### PR DESCRIPTION
The maven-javadoc-plugin version is defined in the shared config pom.xml.
https://github.com/googleapis/java-shared-config/blob/778a547a09de71dbf9e5a42b155f12d15c319864/pom.xml#L472

The removal of the 4 lines corresponds to the lines touched by the recent RenovateBot:
https://github.com/googleapis/java-firestore/pull/1427

Parent issue: https://github.com/googleapis/java-shared-config/issues/673