### PR TITLE
test: prime watch before running tests.

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITBaseTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITBaseTest.java
@@ -35,7 +35,7 @@ public abstract class ITBaseTest {
   private FirestoreOptions firestoreOptions;
 
   @Before
-  public void before() {
+  public void before() throws Exception {
     FirestoreOptions.Builder optionsBuilder = FirestoreOptions.newBuilder();
 
     String namedDb = System.getProperty("FIRESTORE_NAMED_DATABASE");

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITBulkWriterTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITBulkWriterTest.java
@@ -48,7 +48,7 @@ public class ITBulkWriterTest extends ITBaseTest {
   @Rule public TestName testName = new TestName();
 
   @Before
-  public void before() {
+  public void before() throws Exception {
     super.before();
     randomColl =
         firestore.collection(

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -126,7 +126,7 @@ public class ITSystemTest extends ITBaseTest {
   private DocumentReference randomDoc;
 
   @Before
-  public void before() {
+  public void before() throws Exception {
     super.before();
 
     randomColl =


### PR DESCRIPTION
This should hopefully help eliminate some of the flakiness we see, such as: https://github.com/googleapis/java-firestore/issues?page=1&q=is%3Aissue+label%3A%22flakybot%3A+issue%22+ITQueryWatchTest

This was ported from https://github.com/firebase/firebase-android-sdk/blob/080e1fcd3a3632fd21b49d8cb4076bc0d34d2904/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java#L212-L246