### PR TITLE
fix: Make rollback best effort.

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Transaction.java
@@ -124,22 +124,26 @@ public final class Transaction extends UpdateBuilder<Transaction> {
   /** Rolls a transaction back and releases all read locks. */
   ApiFuture<Void> rollback() {
     Tracing.getTracer().getCurrentSpan().addAnnotation(TraceUtil.SPAN_NAME_ROLLBACK);
-    RollbackRequest req = RollbackRequest.newBuilder()
-        .setTransaction(transactionId)
-        .setDatabase(firestore.getDatabaseName())
-        .build();
+    RollbackRequest req =
+        RollbackRequest.newBuilder()
+            .setTransaction(transactionId)
+            .setDatabase(firestore.getDatabaseName())
+            .build();
 
     ApiFuture<Empty> rollbackFuture =
         firestore.sendRequest(req, firestore.getClient().rollbackCallable());
 
-    ApiFuture<Void> transform = ApiFutures.transform(rollbackFuture, resp -> null,
-        MoreExecutors.directExecutor());
+    ApiFuture<Void> transform =
+        ApiFutures.transform(rollbackFuture, resp -> null, MoreExecutors.directExecutor());
 
     return ApiFutures.catching(
         transform,
         Throwable.class,
         (error) -> {
-          LOGGER.log(Level.WARNING, "Failed best effort to rollback of transaction " + transactionId, error);
+          LOGGER.log(
+              Level.WARNING,
+              "Failed best effort to rollback of transaction " + transactionId,
+              error);
           return null;
         },
         MoreExecutors.directExecutor());

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
@@ -1196,10 +1196,6 @@ public final class LocalFirestoreHelper {
         Answer<ApiFuture<? extends GeneratedMessageV3>> answer =
             invocationOnMock -> {
               actualRequestList.add(invocationOnMock.getArguments()[0]);
-              if (!entry.request.equals(invocationOnMock.getArguments()[0])) {
-                System.out.println("BAD INVOCATION");
-                System.out.println(invocationOnMock.getArguments()[0]);
-              }
               return entry.response;
             };
         stubber = (stubber != null) ? stubber.doAnswer(answer) : doAnswer(answer);

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
@@ -1215,8 +1215,7 @@ public final class LocalFirestoreHelper {
       assertArrayEquals(
           "Expected requests, but got actual requests",
           operationList.stream().map(x -> x.request).toArray(),
-          actualRequestList.toArray()
-      );
+          actualRequestList.toArray());
     }
   }
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
@@ -516,11 +516,11 @@ public class TransactionTest {
 
     // Regardless of exception thrown by rollback, we should never retry
     // calling rollback. Rollback is best effort, and will sometimes return
-    // INTERNAL error (which is retryable) when transaction no longer exists
-    // on Firestore server side. Attempting to retry will in some cases simply
-    // exhaust retries with accumulated backoff delay, when a new transaction
-    // could simply be started (since the old transaction no longer exists
-    // server side).
+    // ABORT error (which a transaction will retry) when transaction no longer
+    // exists on Firestore server side. Attempting to retry will in some cases
+    // simply exhaust retries with accumulated backoff delay, when a new
+    // transaction could simply be started (since the old transaction no longer
+    // exists server side).
     verifyRetries(
         /* expectedSequenceWithRetry= */ e -> {
           return new ResponseStubber() {


### PR DESCRIPTION
Internal tracking: b/318686162

A rollback is meant to be best effort. If the transaction has already expired, it is possible for the rollback to fail due to transaction no longer existing in Firestore. The retry logic will use attempts to rollback, and in the case where transaction no longer exists, all attempts to be exhausted attempted to rollback transaction.

This PR makes the rollback best effort, simply logging any rollback error and continuing.

