### PR TITLE
Firestore: Remove obsolete special case from tests when verifying "missing index" error message in non-default DB

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryAggregationsTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryAggregationsTest.java
@@ -1101,10 +1101,6 @@ public class ITQueryAggregationsTest extends ITBaseTest {
 
     Throwable throwable = executionException.getCause();
     assertThat(throwable).hasMessageThat().ignoringCase().contains("index");
-    // TODO(b/316359394) Remove this check for the default databases once cl/582465034 is rolled out
-    //  to production.
-    if (collection.getFirestore().getOptions().getDatabaseId().equals("(default)")) {
-      assertThat(throwable).hasMessageThat().contains("https://console.firebase.google.com");
-    }
+    assertThat(throwable).hasMessageThat().contains("https://console.firebase.google.com");
   }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITQueryCountTest.java
@@ -386,11 +386,7 @@ public class ITQueryCountTest extends ITBaseTest {
 
     Throwable throwable = executionException.getCause();
     assertThat(throwable).hasMessageThat().ignoringCase().contains("index");
-    // TODO(b/316359394) Remove this check for the default databases once cl/582465034 is rolled out
-    //  to production.
-    if (collection.getFirestore().getOptions().getDatabaseId().equals("(default)")) {
-      assertThat(throwable).hasMessageThat().contains("https://console.firebase.google.com");
-    }
+    assertThat(throwable).hasMessageThat().contains("https://console.firebase.google.com");
   }
 
   private CollectionReference createEmptyCollection() {


### PR DESCRIPTION
This PR removes a special case from the integration tests (https://github.com/googleapis/java-firestore/pull/1073) that verifies the "missing index" error message returned from the server. Previously, a non-default database would result in a different, less descriptive error message; however, the backend was updated to use the same, descriptive error message for both default and non-default databases. The tests, therefore, should have to the special case removed to increase the coverage of the tests.

Googlers see b/316359394 for more information.