### PR TITLE
refactor: Optimize FieldMask instantiation

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FieldMask.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FieldMask.java
@@ -19,6 +19,7 @@ package com.google.cloud.firestore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -47,7 +48,7 @@ public final class FieldMask {
    */
   @Nonnull
   public static FieldMask of(String... fieldPaths) {
-    List<FieldPath> paths = new ArrayList<>();
+    TreeSet<FieldPath> paths = new TreeSet<>();
     for (String fieldPath : fieldPaths) {
       paths.add(FieldPath.fromDotSeparatedString(fieldPath));
     }
@@ -62,16 +63,18 @@ public final class FieldMask {
    */
   @Nonnull
   public static FieldMask of(FieldPath... fieldPaths) {
-    return new FieldMask(Arrays.asList(fieldPaths));
+    TreeSet<FieldPath> paths = new TreeSet<>();
+    Collections.addAll(paths, fieldPaths);
+    return new FieldMask(paths);
   }
 
   static FieldMask fromObject(Map<String, Object> values) {
-    List<FieldPath> fieldPaths = extractFromMap(values, FieldPath.empty());
+    TreeSet<FieldPath> fieldPaths = extractFromMap(values, FieldPath.empty());
     return new FieldMask(fieldPaths);
   }
 
-  private static List<FieldPath> extractFromMap(Map<String, Object> values, FieldPath path) {
-    List<FieldPath> fieldPaths = new ArrayList<>();
+  private static TreeSet<FieldPath> extractFromMap(Map<String, Object> values, FieldPath path) {
+    TreeSet<FieldPath> fieldPaths = new TreeSet<>();
 
     for (Map.Entry<String, Object> entry : values.entrySet()) {
       Object value = entry.getValue();

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FieldMask.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FieldMask.java
@@ -16,11 +16,8 @@
 
 package com.google.cloud.firestore;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -275,9 +275,10 @@ public abstract class UpdateBuilder<T> {
         DocumentTransform.fromFieldPathMap(documentReference, documentData);
 
     if (options.getFieldMask() != null) {
-      TreeSet<FieldPath> fieldPaths = options.getFieldMask().stream()
-          .filter(not(documentTransform.getFields()::contains))
-          .collect(toCollection(TreeSet::new));
+      TreeSet<FieldPath> fieldPaths =
+          options.getFieldMask().stream()
+              .filter(not(documentTransform.getFields()::contains))
+              .collect(toCollection(TreeSet::new));
       documentMask = new FieldMask(fieldPaths);
     } else if (options.isMerge()) {
       documentMask = FieldMask.fromObject(fields);
@@ -550,9 +551,10 @@ public abstract class UpdateBuilder<T> {
             });
     DocumentTransform documentTransform =
         DocumentTransform.fromFieldPathMap(documentReference, fields);
-    TreeSet<FieldPath> fieldPaths = fields.keySet().stream()
-        .filter(not(documentTransform.getFields()::contains))
-        .collect(toCollection(TreeSet::new));
+    TreeSet<FieldPath> fieldPaths =
+        fields.keySet().stream()
+            .filter(not(documentTransform.getFields()::contains))
+            .collect(toCollection(TreeSet::new));
     FieldMask fieldMask = new FieldMask(fieldPaths);
 
     Write.Builder write = documentSnapshot.toPb();

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.firestore;
 
+import static com.google.common.base.Predicates.not;
+import static java.util.stream.Collectors.toCollection;
+
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalExtensionOnly;
@@ -272,9 +275,10 @@ public abstract class UpdateBuilder<T> {
         DocumentTransform.fromFieldPathMap(documentReference, documentData);
 
     if (options.getFieldMask() != null) {
-      List<FieldPath> fieldMask = new ArrayList<>(options.getFieldMask());
-      fieldMask.removeAll(documentTransform.getFields());
-      documentMask = new FieldMask(fieldMask);
+      TreeSet<FieldPath> fieldPaths = options.getFieldMask().stream()
+          .filter(not(documentTransform.getFields()::contains))
+          .collect(toCollection(TreeSet::new));
+      documentMask = new FieldMask(fieldPaths);
     } else if (options.isMerge()) {
       documentMask = FieldMask.fromObject(fields);
     }
@@ -544,10 +548,11 @@ public abstract class UpdateBuilder<T> {
                 return true;
               }
             });
-    List<FieldPath> fieldPaths = new ArrayList<>(fields.keySet());
     DocumentTransform documentTransform =
         DocumentTransform.fromFieldPathMap(documentReference, fields);
-    fieldPaths.removeAll(documentTransform.getFields());
+    TreeSet<FieldPath> fieldPaths = fields.keySet().stream()
+        .filter(not(documentTransform.getFields()::contains))
+        .collect(toCollection(TreeSet::new));
     FieldMask fieldMask = new FieldMask(fieldPaths);
 
     Write.Builder write = documentSnapshot.toPb();


### PR DESCRIPTION
Optimization does 2 things:

1. Avoid creating intermediary collections. Simply create a TreeSet that is used in FieldMask constructor.
2. Instead of adding FieldPaths to an intermediary collection and then removing them afterwards, simply filter FieldPaths as part of TreeSet creation.