### PR TITLE
fix: Allow an explicit MustExist precondition for update

### DIFF
--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-conformance-tests</artifactId>
-      <version>0.3.6</version>
+      <version>0.3.7</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Precondition.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Precondition.java
@@ -62,8 +62,8 @@ public final class Precondition {
     return exists == null && updateTime == null;
   }
 
-  boolean hasExists() {
-    return exists != null;
+  Boolean getExists() {
+    return exists;
   }
 
   com.google.firestore.v1.Precondition toPb() {

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UpdateBuilder.java
@@ -387,7 +387,8 @@ public abstract class UpdateBuilder<T> {
       @Nonnull Map<String, Object> fields,
       Precondition precondition) {
     Preconditions.checkArgument(
-        !precondition.hasExists(), "Precondition 'exists' cannot be specified for update() calls.");
+        !Boolean.FALSE.equals(precondition.getExists()),
+        "Precondition 'exists' cannot have the value 'false' for update() calls.");
     return performUpdate(
         documentReference, convertToFieldPaths(fields, /* splitOnDots= */ true), precondition);
   }
@@ -455,7 +456,8 @@ public abstract class UpdateBuilder<T> {
       @Nullable Object value,
       Object... moreFieldsAndValues) {
     Preconditions.checkArgument(
-        !precondition.hasExists(), "Precondition 'exists' cannot be specified for update() calls.");
+        !Boolean.FALSE.equals(precondition.getExists()),
+        "Precondition 'exists' cannot have the value 'false' for update() calls.");
     return performUpdate(
         documentReference,
         precondition,
@@ -483,7 +485,8 @@ public abstract class UpdateBuilder<T> {
       @Nullable Object value,
       Object... moreFieldsAndValues) {
     Preconditions.checkArgument(
-        !precondition.hasExists(), "Precondition 'exists' cannot be specified for update() calls.");
+        !Boolean.FALSE.equals(precondition.getExists()),
+        "Precondition 'exists' cannot have the value 'false' for update() calls.");
     return performUpdate(documentReference, precondition, fieldPath, value, moreFieldsAndValues);
   }
 


### PR DESCRIPTION
This addresses a bug reported against the .NET SDK (https://github.com/googleapis/google-cloud-dotnet/issues/11361) but applies to all SDKs. The conformance test was updated accordingly in https://github.com/googleapis/conformance-tests/pull/82 and https://github.com/googleapis/conformance-tests/pull/84.

This PR is a port of https://github.com/googleapis/nodejs-firestore/pull/1985.

Googlers see b/321064909 for more information.