### PR TITLE
chore: use sdk-platform-java-config to consolidate build config

### DIFF
--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,11 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-<<<<<<< Updated upstream
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
-=======
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.25.0"
->>>>>>> Stashed changes
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.25.0"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,11 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
+<<<<<<< Updated upstream
   value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
+=======
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.25.0"
+>>>>>>> Stashed changes
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,11 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
+<<<<<<< Updated upstream
   value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
+=======
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.25.0"
+>>>>>>> Stashed changes
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,11 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-<<<<<<< Updated upstream
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
-=======
   value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.25.0"
->>>>>>> Stashed changes
 }
 
 env_vars: {

--- a/google-cloud-firestore-bom/pom.xml
+++ b/google-cloud-firestore-bom/pom.xml
@@ -7,13 +7,8 @@
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
-<<<<<<< Updated upstream
-    <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.7.1</version>
-=======
     <artifactId>sdk-platform-java-config</artifactId>
     <version>3.25.0</version>
->>>>>>> Stashed changes
   </parent>
 
   <name>Google Cloud Firestore BOM</name>

--- a/google-cloud-firestore-bom/pom.xml
+++ b/google-cloud-firestore-bom/pom.xml
@@ -7,8 +7,13 @@
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
+<<<<<<< Updated upstream
     <artifactId>google-cloud-shared-config</artifactId>
     <version>1.7.1</version>
+=======
+    <artifactId>sdk-platform-java-config</artifactId>
+    <version>3.25.0</version>
+>>>>>>> Stashed changes
   </parent>
 
   <name>Google Cloud Firestore BOM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
   <parent>
     <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.7.1</version>
+    <artifactId>sdk-platform-java-config</artifactId>
+    <version>3.25.0</version>
   </parent>
 
   <developers>
@@ -181,7 +181,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.25.0</version>
+        <version>${google-cloud-shared-dependencies.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Notable Changes:
1) Use `gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform*` docker images for Kokoro GraalVM tests  instead of `gcr.io/cloud-devrel-kokoro-resources/graalvm*`.
2) Use `com.google.cloud:sdk-platform-java-config` as the parent which inherits configs from `java-shared-config` and hosts the `google-cloud-shared-dependencies` version under the `google-cloud-shared-dependencies.version` property.  This artifact is versioned to be the same as google-cloud-shared-dependencies.
3) Adjust renovate-bot settings to update docker images when a new version of `sdk-platform-java-config` is on Maven Central.

Example renovate-bot update PR in google-cloud-java: https://github.com/googleapis/google-cloud-java/pull/10290
