### PR TITLE
fix: update DocFX profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,27 @@
         <!-- exclude file causing error generating doc -->
         <sourceFileExclude>com/google/cloud/firestore/v1/package-info.java</sourceFileExclude>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <sourceFileExcludes>
+                <exclude>${sourceFileExclude}</exclude>
+              </sourceFileExcludes>
+            </configuration>
+            <executions>
+              <execution>
+                <id>aggregate</id>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Currently, firestore cloud.google.com DocFX generation fails:

```
Error: 5:736 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.6.3:aggregate (default-cli) on project google-cloud-firestore-parent: An error has occurred in Javadoc report generation: 
Error: 5:736 [ERROR] Exit code: 1
Error: 5:736 [ERROR] Note: Doclet using locale: en
Error: 5:736 [ERROR] /home/runner/work/java-shared-config/java-shared-config/sdk-platform-java/java-firestore/google-cloud-firestore-admin/src/main/java/com/google/cloud/firestore/v1/package-info.java:66: warning: a package-info.java file has already been seen for package com.google.cloud.firestore.v1
Error: 5:736 [ERROR] package com.google.cloud.firestore.v1;
Error: 5:736 [ERROR]                                   ^
```

The current DocFX profile excludes that file for this reason: https://github.com/googleapis/java-firestore/blob/main/pom.xml#L263. 
However, there was a recent change made to the shared DocFX profile (https://github.com/googleapis/java-shared-config/pull/744) that removed some of these properties due to an unrelated issue caused by the maven-javadoc-plugin upgrade to 3.6.3 that no longer allows null parameters to be passed in. That change caused this property to no longer be respected with DocFX generation. 

This PR updates the Firestore profile such that the file exclusion property should be respected during javadoc generation (to be confirmed in https://github.com/googleapis/java-shared-config/pull/771). 