### PR TITLE
test: End-to-End Integration Test for Client-side Tracing in Firestore Java Server SDK using OpenTelemetry SDK and Cloud Trace Exporter against Cloud Trace.

### DIFF
--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -105,6 +105,7 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
     </dependency>
+
     <!-- OpenTelemetry -->
     <dependency>
       <groupId>io.opentelemetry</groupId>
@@ -213,7 +214,41 @@
       <version>${opentelemetry.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.opentelemetry</groupId>
+      <artifactId>exporter-trace</artifactId>
+      <version>0.15.0</version>
+      <scope>test</scope>
+    </dependency>
     <!-- END OpenTelemetry -->
+    <!-- Cloud Ops -->
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-trace-v1</artifactId>
+      <version>1.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.opentelemetry</groupId>
+      <artifactId>exporter-trace</artifactId>
+      <version>0.15.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- END OpenTelemetry -->
+    <!-- Cloud Ops -->
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-trace-v1</artifactId>
+      <version>1.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-trace</artifactId>
+      <version>1.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- END Cloud Ops -->
   </dependencies>
 
   <reporting>

--- a/google-cloud-firestore/pom.xml
+++ b/google-cloud-firestore/pom.xml
@@ -248,6 +248,12 @@
       <version>1.3.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.testparameterinjector</groupId>
+      <artifactId>test-parameter-injector</artifactId>
+      <version>1.15</version>
+      <scope>test</scope>
+    </dependency>
     <!-- END Cloud Ops -->
   </dependencies>
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
@@ -438,8 +438,11 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   // Validates `retrievedTrace`. Cloud Trace indexes traces w/ eventual consistency, even when
-  // indexing traceId, therefore the
-  // test must retry a few times before the complete trace is available.
+  // indexing traceId, therefore the test must retry a few times before the complete trace is
+  // available.
+  // For Transaction traces, there may be more spans than in the trace than specified in
+  // `callStack`. So `numExpectedSpans` is the expected total number of spans (and not just the
+  // spans in `callStack`)
   protected void fetchAndValidateTransactionTrace(
       String traceId, int numExpectedSpans, String... callStack) throws InterruptedException {
     // Large enough count to accommodate eventually consistent Cloud Trace backend
@@ -489,9 +492,10 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   // Validates `retrievedTrace`. Cloud Trace indexes traces w/ eventual consistency, even when
-  // indexing traceId, therefore the
-  // test must retry a few times before the complete trace is available.
-  protected void fetchAndValidateTraces(String traceId, String... spanNames)
+  // indexing traceId, therefore the test must retry a few times before the complete trace is
+  // available.
+  // For Non-Transaction traces, there is a 1:1 ratio of spans in `spanNames` and in the trace.
+  protected void fetchAndValidateNonTransactionTrace(String traceId, String... spanNames)
       throws InterruptedException {
     int numRetries = GET_TRACE_RETRY_COUNT;
     do {
@@ -593,7 +597,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         "AggregationQuery.Get",
         grpcSpanName(RUN_AGGREGATION_QUERY_RPC_NAME));
@@ -622,7 +626,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_BULK_WRITER_COMMIT,
         grpcSpanName(BATCH_WRITE_RPC_NAME));
@@ -644,7 +648,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_PARTITION_QUERY,
         grpcSpanName(SPAN_NAME_PARTITION_QUERY));
@@ -665,7 +669,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_COL_REF_LIST_DOCUMENTS,
         grpcSpanName(LIST_DOCUMENTS_RPC_NAME));
@@ -686,7 +690,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_CREATE,
         SPAN_NAME_BATCH_COMMIT,
@@ -708,7 +712,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_CREATE,
         SPAN_NAME_BATCH_COMMIT,
@@ -730,7 +734,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_SET,
         SPAN_NAME_BATCH_COMMIT,
@@ -756,7 +760,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_SET,
         SPAN_NAME_BATCH_COMMIT,
@@ -778,7 +782,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_SET,
         SPAN_NAME_BATCH_COMMIT,
@@ -800,7 +804,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_SET,
         SPAN_NAME_BATCH_COMMIT,
@@ -808,7 +812,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefUpdate() throws Exception {
+  public void docRefUpdateTraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -826,7 +830,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_UPDATE,
         SPAN_NAME_BATCH_COMMIT,
@@ -834,7 +838,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefUpdate2() throws Exception {
+  public void docRefUpdate2TraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -852,7 +856,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_UPDATE,
         SPAN_NAME_BATCH_COMMIT,
@@ -860,7 +864,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefUpdate3() throws Exception {
+  public void docRefUpdate3TraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -874,7 +878,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_UPDATE,
         SPAN_NAME_BATCH_COMMIT,
@@ -882,7 +886,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefUpdate4() throws Exception {
+  public void docRefUpdate4TraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -900,7 +904,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_UPDATE,
         SPAN_NAME_BATCH_COMMIT,
@@ -908,7 +912,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefUpdate5() throws Exception {
+  public void docRefUpdate5TraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -926,7 +930,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_UPDATE,
         SPAN_NAME_BATCH_COMMIT,
@@ -934,7 +938,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefUpdate6() throws Exception {
+  public void docRefUpdate6TraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -952,7 +956,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_UPDATE,
         SPAN_NAME_BATCH_COMMIT,
@@ -960,7 +964,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefDelete() throws Exception {
+  public void docRefDeleteTraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -974,7 +978,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_DELETE,
         SPAN_NAME_BATCH_COMMIT,
@@ -982,7 +986,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefDelete2() throws Exception {
+  public void docRefDelete2TraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -996,7 +1000,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_DELETE,
         SPAN_NAME_BATCH_COMMIT,
@@ -1004,7 +1008,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void docRefGet() throws Exception {
+  public void docRefGetTraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -1018,14 +1022,14 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_GET,
         grpcSpanName(BATCH_GET_DOCUMENTS_RPC_NAME));
   }
 
   @Test
-  public void docRefGet2() throws Exception {
+  public void docRefGet2TraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -1039,14 +1043,14 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_GET,
         grpcSpanName(BATCH_GET_DOCUMENTS_RPC_NAME));
   }
 
   @Test
-  public void docListCollections() throws Exception {
+  public void docListCollectionsTraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -1060,14 +1064,14 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(),
         SPAN_NAME_DOC_REF_LIST_COLLECTIONS,
         grpcSpanName(LIST_COLLECTIONS_RPC_NAME));
   }
 
   @Test
-  public void getAll() throws Exception {
+  public void getAllTraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -1083,12 +1087,12 @@ public class ITE2ETracingTest extends ITBaseTest {
     }
     waitForTracesToComplete();
 
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(), grpcSpanName(BATCH_GET_DOCUMENTS_RPC_NAME));
   }
 
   @Test
-  public void queryGet() throws Exception {
+  public void queryGetTraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -1101,12 +1105,12 @@ public class ITE2ETracingTest extends ITBaseTest {
     }
     waitForTracesToComplete();
 
-    fetchAndValidateTraces(
+    fetchAndValidateNonTransactionTrace(
         customSpanContext.getTraceId(), SPAN_NAME_QUERY_GET, grpcSpanName(RUN_QUERY_RPC_NAME));
   }
 
   @Test
-  public void transaction() throws Exception {
+  public void transactionTraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 
@@ -1180,7 +1184,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void transactionRollback() throws Exception {
+  public void transactionRollbackTraceTest() throws Exception {
     String myErrorMessage = "My error message.";
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
@@ -1220,7 +1224,7 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void writeBatch() throws Exception {
+  public void writeBatchTraceTest() throws Exception {
     // Make sure the test has a new SpanContext (and TraceId for injection)
     assertNotNull(customSpanContext);
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
@@ -27,10 +27,19 @@ import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_DOC_REF_S
 import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_DOC_REF_UPDATE;
 import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_PARTITION_QUERY;
 import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_QUERY_GET;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_BEGIN;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_COMMIT;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_GET_AGGREGATION_QUERY;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_GET_DOCUMENTS;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_GET_QUERY;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_ROLLBACK;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.firestore.BulkWriter;
@@ -43,13 +52,16 @@ import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOpenTelemetryOptions;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.firestore.Precondition;
+import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.SetOptions;
+import com.google.cloud.firestore.WriteBatch;
 import com.google.cloud.firestore.it.ITTracingTest.Pojo;
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
 import com.google.cloud.trace.v1.TraceServiceClient;
 import com.google.common.base.Preconditions;
 import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.TraceSpan;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -67,7 +79,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.TreeMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -81,8 +96,119 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+// This End-to-End test verifies Client-side Tracing Functionality instrumented using the
+// OpenTelemetry API.
+// The test depends on the following external APIs/Services:
+// 1. Java OpenTelemetry SDK
+// 2. Cloud Trace Exporter
+// 3. TraceServiceClient from Cloud Trace API v1.
+//
+// Permissions required to run this test (https://cloud.google.com/trace/docs/iam#trace-roles):
+// 1. gcloud auth application-default login must be run with the test user.
+// 2. To write traces, test user must have one of roles/cloudtrace.[admin|agent|user] roles.
+// 3. To read traces, test user must have one of roles/cloudtrace.[admin|user] roles.
+//
+// Each test-case has the following workflow:
+// 1. OpenTelemetry SDK is initialized with Cloud Trace Exporter and 100% Trace Sampling
+// 2. On initialization, Firestore client is provided the OpenTelemetry SDK object from (1)
+// 3. A custom TraceID is generated and injected using a custom SpanContext
+// 4. Firestore operations are run inside a root TraceSpan created using the custom SpanContext from
+// (3).
+// 5. Traces are read-back using TraceServiceClient and verified against expected Call Stacks.
+// TODO In the future it would be great to have a single test-driver for this test and
+// ITTracingTest.
 @RunWith(JUnit4.class)
 public class ITE2ETracingTest extends ITBaseTest {
+
+  // Helper class to track call-stacks in a trace
+  protected class TraceContainer {
+
+    // Maps Span ID to TraceSpan
+    private Map<Long, TraceSpan> idSpanMap;
+
+    // Maps Parent Span ID to a list of Child SpanIDs, useful for top-down traversal
+    private Map<Long, List<Long>> parentChildIdMap;
+
+    // Tracks the Root Span ID
+    private long rootId;
+
+    public TraceContainer(String rootSpanName, Trace trace) {
+      idSpanMap = new TreeMap<Long, TraceSpan>();
+      parentChildIdMap = new TreeMap<Long, List<Long>>();
+      for (TraceSpan span : trace.getSpansList()) {
+        long spanId = span.getSpanId();
+        idSpanMap.put(spanId, span);
+        if (rootSpanName.equals(span.getName())) {
+          rootId = span.getSpanId();
+        }
+
+        // Add self as a child of the parent span
+        if (!parentChildIdMap.containsKey(span.getParentSpanId())) {
+          parentChildIdMap.put(span.getParentSpanId(), new ArrayList<Long>());
+        }
+        parentChildIdMap.get(span.getParentSpanId()).add(spanId);
+      }
+    }
+
+    String spanName(long spanId) {
+      return idSpanMap.get(spanId).getName();
+    }
+
+    List<Long> childSpans(long spanId) {
+      return parentChildIdMap.get(spanId);
+    }
+
+    // This method only works for matching call stacks with traces which have children of distinct
+    // type at all
+    // levels. This is good enough as the intention is to validate if the e2e path is WAI - the
+    // intention is not to validate Cloud Trace's correctness w.r.t. durability of all kinds of
+    // traces.
+    boolean containsCallStack(String... callStack) throws RuntimeException {
+      ArrayList<String> expectedCallStack = new ArrayList<String>();
+      for (String call : callStack) {
+        expectedCallStack.add(call);
+      }
+      if (expectedCallStack.isEmpty()) {
+        throw new RuntimeException("Input callStack is empty");
+      }
+      return dfsContainsCallStack(rootId, expectedCallStack);
+    }
+
+    // Depth-first check for call stack in the trace
+    private boolean dfsContainsCallStack(long spanId, List<String> expectedCallStack) {
+      logger.info(
+          "span="
+              + spanName(spanId)
+              + ", expectedCallStack[0]="
+              + (expectedCallStack.isEmpty() ? "null" : expectedCallStack.get(0)));
+      if (!expectedCallStack.isEmpty() && spanName(spanId).equals(expectedCallStack.get(0))) {
+        if (childSpans(spanId) == null) {
+          logger.info("No more chilren for " + spanName(spanId));
+          return true;
+        } else {
+          for (Long childSpan : childSpans(spanId)) {
+            int callStackListSize = expectedCallStack.size();
+            logger.info(
+                "childSpan="
+                    + spanName(childSpan)
+                    + ", expectedCallStackSize="
+                    + callStackListSize);
+            if (dfsContainsCallStack(
+                childSpan,
+                expectedCallStack.subList(
+                    /*fromIndexInclusive=*/ 1, /*toIndexExclusive*/ callStackListSize))) {
+              return true;
+            }
+          }
+        }
+      } else {
+        if (!expectedCallStack.isEmpty()) {
+          logger.warning(spanName(spanId) + " didn't match " + expectedCallStack.get(0));
+        }
+      }
+      return false;
+    }
+  }
 
   private static final Logger logger = Logger.getLogger(ITBaseTest.class.getName());
 
@@ -92,11 +218,15 @@ public class ITE2ETracingTest extends ITBaseTest {
 
   private static final String BATCH_WRITE_RPC_NAME = "BatchWrite";
 
+  private static final String BEGIN_TRANSACTION_RPC_NAME = "BeginTransaction";
+
   private static final String COMMIT_RPC_NAME = "Commit";
 
   private static final String LIST_COLLECTIONS_RPC_NAME = "ListCollectionIds";
 
   private static final String LIST_DOCUMENTS_RPC_NAME = "ListDocuments";
+
+  private static final String ROLLBACK_RPC_NAME = "Rollback";
 
   private static final String RUN_AGGREGATION_QUERY_RPC_NAME = "RunAggregationQuery";
 
@@ -269,6 +399,57 @@ public class ITE2ETracingTest extends ITBaseTest {
   // Validates `retrievedTrace`. Cloud Trace indexes traces w/ eventual consistency, even when
   // indexing traceId, therefore the
   // test must retry a few times before the complete trace is available.
+  protected void fetchAndValidateTransactionTrace(
+      String traceId, int numExpectedSpans, String... callStack) throws InterruptedException {
+    // Large enough count to accommodate eventually consistent Cloud Trace backend
+    int numRetries = GET_TRACE_RETRY_COUNT;
+    do {
+      try {
+        // Fetch traces
+        retrievedTrace = traceClient_v1.getTrace(projectId, traceId);
+        assertEquals(traceId, retrievedTrace.getTraceId());
+
+        ArrayList<String> expectedCallStack = new ArrayList<String>(Arrays.asList(callStack));
+
+        // numExpectedSpans should account for rootSpanName (which is not passed in callStack)
+        expectedCallStack.add(0, rootSpanName);
+        numExpectedSpans++;
+
+        System.out.println(
+            "expectedSpanCount="
+                + numExpectedSpans
+                + ", retrievedSpanCount="
+                + retrievedTrace.getSpansCount());
+        // *Maybe* the full trace was returned
+        if (retrievedTrace.getSpansCount() == numExpectedSpans) {
+          System.out.println("Checking if TraceContainer containsCallStack");
+          TraceContainer traceContainer = new TraceContainer(rootSpanName, retrievedTrace);
+          String[] temp = new String[expectedCallStack.size()];
+          if (traceContainer.containsCallStack(expectedCallStack.toArray(temp))) {
+            return;
+          }
+          logger.severe("CallStack not found in TraceContainer.");
+        } // else the trace may not have been fully committed to Cloud Trace storage
+      } catch (NotFoundException notFound) {
+        logger.info("Trace not found, retrying in " + GET_TRACE_RETRY_BACKOFF_MILLIS + " ms");
+        Thread.sleep(GET_TRACE_RETRY_BACKOFF_MILLIS);
+        // getTrace could fail
+      } catch (IndexOutOfBoundsException outOfBoundsException) {
+        logger.info("Call stack not found in trace. Retrying.");
+        Thread.sleep(GET_TRACE_RETRY_BACKOFF_MILLIS);
+      }
+      // Retrieved trace doesn't have expected number of spans
+    } while (numRetries-- > 0);
+    throw new RuntimeException(
+        "Expected spans: "
+            + callStack.toString()
+            + ", Actual spans: "
+            + (retrievedTrace != null ? retrievedTrace.getSpansList().toString() : "null"));
+  }
+
+  // Validates `retrievedTrace`. Cloud Trace indexes traces w/ eventual consistency, even when
+  // indexing traceId, therefore the
+  // test must retry a few times before the complete trace is available.
   protected void fetchAndValidateTraces(String traceId, String... spanNames)
       throws InterruptedException {
     int numRetries = GET_TRACE_RETRY_COUNT;
@@ -302,6 +483,56 @@ public class ITE2ETracingTest extends ITBaseTest {
             + spanNames.toString()
             + ", Actual spans: "
             + (retrievedTrace != null ? retrievedTrace.getSpansList().toString() : "null"));
+  }
+
+  @Test
+  public void traceContainerTest() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").whereEqualTo("foo", "my_non_existent_value").get().get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    Trace traceResp = null;
+    int expectedSpanCount = 3;
+
+    int numRetries = GET_TRACE_RETRY_COUNT;
+    do {
+      try {
+        traceResp = traceClient_v1.getTrace(projectId, customSpanContext.getTraceId());
+        if (traceResp.getSpansCount() == expectedSpanCount) {
+          break;
+        }
+      } catch (NotFoundException notFoundException) {
+        Thread.sleep(GET_TRACE_RETRY_BACKOFF_MILLIS);
+        logger.info("Trace not found, retrying in " + GET_TRACE_RETRY_BACKOFF_MILLIS + " ms");
+      }
+      numRetries--;
+    } while (numRetries > 0);
+
+    TraceContainer traceCont = new TraceContainer(rootSpanName, traceResp);
+
+    // Contains exact path
+    assertTrue(
+        traceCont.containsCallStack(
+            rootSpanName, SPAN_NAME_QUERY_GET, grpcSpanName(RUN_QUERY_RPC_NAME)));
+
+    // Top-level mismatch
+    assertFalse(traceCont.containsCallStack(SPAN_NAME_QUERY_GET, RUN_QUERY_RPC_NAME));
+
+    // Mid-level match
+    assertFalse(traceCont.containsCallStack(rootSpanName, SPAN_NAME_QUERY_GET));
+
+    // Leaf-level mismatch/missing
+    assertFalse(
+        traceCont.containsCallStack(
+            rootSpanName, SPAN_NAME_QUERY_GET, RUN_AGGREGATION_QUERY_RPC_NAME));
   }
 
   @Test
@@ -834,11 +1065,142 @@ public class ITE2ETracingTest extends ITBaseTest {
   }
 
   @Test
-  public void transaction() throws Exception {}
+  public void transaction() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore
+          .runTransaction(
+              transaction -> {
+                Query q = firestore.collection("col").whereGreaterThan("bla", "");
+                DocumentReference d = firestore.collection("col").document("foo");
+                DocumentReference[] docList = {d, d};
+                // Document Query.
+                transaction.get(q).get();
+
+                // Aggregation Query.
+                transaction.get(q.count());
+
+                // Get multiple documents.
+                transaction.getAll(d, d).get();
+
+                // Commit 2 documents.
+                transaction.set(
+                    firestore.collection("foo").document("bar"),
+                    Collections.singletonMap("foo", "bar"));
+                transaction.set(
+                    firestore.collection("foo").document("bar2"),
+                    Collections.singletonMap("foo2", "bar2"));
+                return 0;
+              })
+          .get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    fetchAndValidateTransactionTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 11,
+        SPAN_NAME_TRANSACTION_RUN,
+        SPAN_NAME_TRANSACTION_BEGIN,
+        grpcSpanName(BEGIN_TRANSACTION_RPC_NAME));
+
+    fetchAndValidateTransactionTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 11,
+        SPAN_NAME_TRANSACTION_RUN,
+        SPAN_NAME_TRANSACTION_GET_QUERY,
+        grpcSpanName(RUN_QUERY_RPC_NAME));
+
+    fetchAndValidateTransactionTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 11,
+        SPAN_NAME_TRANSACTION_RUN,
+        SPAN_NAME_TRANSACTION_GET_AGGREGATION_QUERY,
+        grpcSpanName(RUN_AGGREGATION_QUERY_RPC_NAME));
+
+    fetchAndValidateTransactionTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 11,
+        SPAN_NAME_TRANSACTION_RUN,
+        SPAN_NAME_TRANSACTION_GET_DOCUMENTS,
+        grpcSpanName(BATCH_GET_DOCUMENTS_RPC_NAME));
+
+    fetchAndValidateTransactionTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 11,
+        SPAN_NAME_TRANSACTION_RUN,
+        SPAN_NAME_TRANSACTION_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
 
   @Test
-  public void transactionRollback() throws Exception {}
+  public void transactionRollback() throws Exception {
+    String myErrorMessage = "My error message.";
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore
+          .runTransaction(
+              transaction -> {
+                if (true) {
+                  throw (new Exception(myErrorMessage));
+                }
+                return 0;
+              })
+          .get();
+    } catch (Exception e) {
+      // Catch and move on.
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    fetchAndValidateTransactionTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 5,
+        SPAN_NAME_TRANSACTION_RUN,
+        SPAN_NAME_TRANSACTION_BEGIN,
+        grpcSpanName(BEGIN_TRANSACTION_RPC_NAME));
+
+    fetchAndValidateTransactionTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 5,
+        SPAN_NAME_TRANSACTION_RUN,
+        SPAN_NAME_TRANSACTION_ROLLBACK,
+        grpcSpanName(ROLLBACK_RPC_NAME));
+  }
 
   @Test
-  public void writeBatch() throws Exception {}
+  public void writeBatch() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      WriteBatch batch = firestore.batch();
+      DocumentReference docRef = firestore.collection("foo").document();
+      batch.create(docRef, Collections.singletonMap("foo", "bar"));
+      batch.update(docRef, Collections.singletonMap("foo", "bar"));
+      batch.delete(docRef);
+      batch.commit().get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    fetchAndValidateTransactionTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 2,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
@@ -169,10 +169,7 @@ public class ITE2ETracingTest extends ITBaseTest {
     // WAI - the intention is not to validate Cloud Trace's correctness w.r.t. durability of all
     // kinds of traces.
     boolean containsCallStack(String... callStack) throws RuntimeException {
-      ArrayList<String> expectedCallStack = new ArrayList<String>();
-      for (String call : callStack) {
-        expectedCallStack.add(call);
-      }
+      List<String> expectedCallStack = Arrays.asList(callStack);
       if (expectedCallStack.isEmpty()) {
         throw new RuntimeException("Input callStack is empty");
       }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
@@ -16,8 +16,14 @@
 
 package com.google.cloud.firestore.it;
 
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_BATCH_COMMIT;
 import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_BULK_WRITER_COMMIT;
 import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_COL_REF_LIST_DOCUMENTS;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_DOC_REF_CREATE;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_DOC_REF_DELETE;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_DOC_REF_GET;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_DOC_REF_SET;
+import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_DOC_REF_UPDATE;
 import static com.google.cloud.firestore.telemetry.TraceUtil.SPAN_NAME_PARTITION_QUERY;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 import static org.junit.Assert.assertEquals;
@@ -28,10 +34,14 @@ import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.firestore.BulkWriter;
 import com.google.cloud.firestore.BulkWriterOptions;
 import com.google.cloud.firestore.CollectionGroup;
+import com.google.cloud.firestore.FieldMask;
+import com.google.cloud.firestore.FieldPath;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOpenTelemetryOptions;
 import com.google.cloud.firestore.FirestoreOptions;
-import com.google.cloud.firestore.telemetry.TraceUtil;
+import com.google.cloud.firestore.Precondition;
+import com.google.cloud.firestore.SetOptions;
+import com.google.cloud.firestore.it.ITTracingTest.Pojo;
 import com.google.cloud.opentelemetry.trace.TraceConfiguration;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
 import com.google.cloud.trace.v1.TraceServiceClient;
@@ -51,9 +61,9 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -75,9 +85,15 @@ public class ITE2ETracingTest extends ITBaseTest {
 
   private static final String SERVICE = "google.firestore.v1.Firestore/";
 
+  private static final String BATCH_GET_DOCUMENTS_RPC_NAME = "BatchGetDocuments";
+
   private static final String BATCH_WRITE_RPC_NAME = "BatchWrite";
 
+  private static final String COMMIT_RPC_NAME = "Commit";
+
   private static final String LIST_DOCUMENTS_RPC_NAME = "ListDocuments";
+
+  private static final String RUN_AGGREGATION_QUERY_RPC_NAME = "RunAggregationQuery";
 
   private static final int NUM_TRACE_ID_BYTES = 32;
 
@@ -87,7 +103,7 @@ public class ITE2ETracingTest extends ITBaseTest {
 
   private static final int GET_TRACE_RETRY_BACKOFF_MILLIS = 1000;
 
-  private static final int TRACE_FORCE_FLUSH_MILLIS = 1000;
+  private static final int TRACE_FORCE_FLUSH_MILLIS = 3000;
 
   private static final int TRACE_PROVIDER_SHUTDOWN_MILLIS = 1000;
 
@@ -141,7 +157,14 @@ public class ITE2ETracingTest extends ITBaseTest {
 
     traceClient_v1 = TraceServiceClient.create();
 
-    // Initialize the Firestore DB w/ the OTel SDK
+    random = new Random();
+  }
+
+  @Before
+  public void before() throws Exception {
+    // Initialize the Firestore DB w/ the OTel SDK. Ideally we'd do this is the @BeforeAll method
+    // but because gRPC traces need to be deterministically force-flushed, firestore.shutdown()
+    // must be called in @After for each test.
     FirestoreOptions.Builder optionsBuilder =
         FirestoreOptions.newBuilder()
             .setOpenTelemetryOptions(
@@ -162,11 +185,6 @@ public class ITE2ETracingTest extends ITBaseTest {
         firestore,
         "Error instantiating Firestore. Check that the service account credentials "
             + "were properly set.");
-    random = new Random();
-  }
-
-  @Before
-  public void before() throws Exception {
     rootSpanName =
         String.format("%s%d", this.getClass().getSimpleName(), System.currentTimeMillis());
     tracer =
@@ -180,6 +198,7 @@ public class ITE2ETracingTest extends ITBaseTest {
 
   @After
   public void after() throws Exception {
+    firestore.shutdown();
     rootSpanName = null;
     tracer = null;
     retrievedTrace = null;
@@ -192,8 +211,6 @@ public class ITE2ETracingTest extends ITBaseTest {
     CompletableResultCode completableResultCode =
         openTelemetrySdk.getSdkTracerProvider().shutdown();
     completableResultCode.join(TRACE_PROVIDER_SHUTDOWN_MILLIS, TimeUnit.MILLISECONDS);
-    firestore.close();
-    firestore.shutdown();
   }
 
   // Generates a random 32-byte hex string
@@ -214,25 +231,6 @@ public class ITE2ETracingTest extends ITBaseTest {
     return generateRandomHexString(NUM_SPAN_ID_BYTES);
   }
 
-  // Cloud Trace indexes traces w/ eventual consistency, even when indexing traceId, therefore the
-  // test must retry a few times before the trace is available.
-  protected Trace getTraceWithRetry(String project, String traceId)
-      throws InterruptedException, RuntimeException {
-    int retryCount = GET_TRACE_RETRY_COUNT;
-
-    while (retryCount-- > 0) {
-      try {
-        Trace t = traceClient_v1.getTrace(project, traceId);
-        return t;
-      } catch (NotFoundException notFound) {
-        logger.warning("Trace not found, retrying in " + GET_TRACE_RETRY_BACKOFF_MILLIS + " ms");
-        Thread.sleep(GET_TRACE_RETRY_BACKOFF_MILLIS);
-      }
-    }
-    throw new RuntimeException(
-        "Trace " + traceId + " for project " + project + " not found in Cloud Trace.");
-  }
-
   // Generates a new SpanContext w/ random traceId,spanId
   protected SpanContext getNewSpanContext() {
     String traceId = generateNewTraceId();
@@ -244,7 +242,8 @@ public class ITE2ETracingTest extends ITBaseTest {
 
   protected Span getNewRootSpanWithContext() {
     // Execute the DB operation in the context of the custom root span.
-    return tracer.spanBuilder(rootSpanName)
+    return tracer
+        .spanBuilder(rootSpanName)
         .setParent(Context.root().with(Span.wrap(customSpanContext)))
         .startSpan();
   }
@@ -260,19 +259,42 @@ public class ITE2ETracingTest extends ITBaseTest {
     completableResultCode.join(TRACE_FORCE_FLUSH_MILLIS, TimeUnit.MILLISECONDS);
   }
 
-  // Validates `retrievedTrace`
+  // Validates `retrievedTrace`. Cloud Trace indexes traces w/ eventual consistency, even when
+  // indexing traceId, therefore the
+  // test must retry a few times before the complete trace is available.
   protected void fetchAndValidateTraces(String traceId, String... spanNames)
       throws InterruptedException {
-    // Fetch traces
-    retrievedTrace = getTraceWithRetry(projectId, traceId);
-    List<String> spanNameList = Arrays.asList(spanNames);
-
-    // Validate trace spans
-    assertEquals(retrievedTrace.getTraceId(), traceId);
-    assertEquals(retrievedTrace.getSpans(0).getName(), rootSpanName);
-    for (int i = 0; i < spanNameList.size() ; ++i) {
-      assertEquals(spanNameList.get(i), retrievedTrace.getSpans(i+1).getName());
-    }
+    int numRetries = GET_TRACE_RETRY_COUNT;
+    do {
+      try {
+        // Fetch traces
+        retrievedTrace = traceClient_v1.getTrace(projectId, traceId);
+        ArrayList<String> spanNameList = new ArrayList<String>(Arrays.asList(spanNames));
+        spanNameList.add(0, rootSpanName);
+        // Validate trace spans
+        assertEquals(traceId, retrievedTrace.getTraceId());
+        for (int i = 0; i < spanNameList.size(); ++i) {
+          assertEquals(spanNameList.get(i), retrievedTrace.getSpans(i).getName());
+        }
+        assertEquals(spanNameList.size(), retrievedTrace.getSpansCount());
+        return;
+      } catch (NotFoundException notFound) {
+        logger.info("Trace not found, retrying in " + GET_TRACE_RETRY_BACKOFF_MILLIS + " ms");
+        Thread.sleep(GET_TRACE_RETRY_BACKOFF_MILLIS);
+      } catch (IndexOutOfBoundsException outOfBoundsException) {
+        logger.info(
+            "Expected # spans: "
+                + (spanNames.length + 1)
+                + "Actual # spans: "
+                + retrievedTrace.getSpansCount());
+        Thread.sleep(GET_TRACE_RETRY_BACKOFF_MILLIS);
+      }
+    } while (numRetries-- > 0);
+    throw new RuntimeException(
+        "Expected spans: "
+            + spanNames.toString()
+            + ", Actual spans: "
+            + (retrievedTrace != null ? retrievedTrace.getSpansList().toString() : "null"));
   }
 
   @Test
@@ -292,7 +314,10 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(customSpanContext.getTraceId(), "AggregationQuery.Get");
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        "AggregationQuery.Get",
+        grpcSpanName(RUN_AGGREGATION_QUERY_RPC_NAME));
   }
 
   @Test
@@ -318,7 +343,8 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(customSpanContext.getTraceId(),
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
         SPAN_NAME_BULK_WRITER_COMMIT,
         grpcSpanName(BATCH_WRITE_RPC_NAME));
   }
@@ -339,7 +365,8 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(customSpanContext.getTraceId(),
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
         SPAN_NAME_PARTITION_QUERY,
         grpcSpanName(SPAN_NAME_PARTITION_QUERY));
   }
@@ -359,57 +386,385 @@ public class ITE2ETracingTest extends ITBaseTest {
     waitForTracesToComplete();
 
     // Read and validate traces
-    fetchAndValidateTraces(customSpanContext.getTraceId(),
-        SPAN_NAME_COL_REF_LIST_DOCUMENTS, grpcSpanName(LIST_DOCUMENTS_RPC_NAME));
-  }
-
-  public void docRefCreate() throws Exception {
-  }
-
-  @Test
-  public void docRefCreate2() throws Exception {
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_COL_REF_LIST_DOCUMENTS,
+        grpcSpanName(LIST_DOCUMENTS_RPC_NAME));
   }
 
   @Test
-  public void docRefSet() throws Exception {}
+  public void docRefCreateTraceTest() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document().create(Collections.singletonMap("foo", "bar")).get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_CREATE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
 
   @Test
-  public void docRefSet2() throws Exception {}
+  public void docRefCreate2TraceTest() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document().create(new Pojo(1)).get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_CREATE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
 
   @Test
-  public void docRefSet3() throws Exception {}
+  public void docRefSetTraceTest() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
 
-  public void docRefSet4() throws Exception {}
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document("foo").set(Collections.singletonMap("foo", "bar")).get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
 
-  @Test
-  public void docRefUpdate() throws Exception {}
-
-  @Test
-  public void docRefUpdate2() throws Exception {}
-
-  @Test
-  public void docRefUpdate3() throws Exception {}
-
-  @Test
-  public void docRefUpdate4() throws Exception {}
-
-  @Test
-  public void docRefUpdate5() throws Exception {}
-
-  @Test
-  public void docRefUpdate6() throws Exception {}
-
-  @Test
-  public void docRefDelete() throws Exception {}
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_SET,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
 
   @Test
-  public void docRefDelete2() throws Exception {}
+  public void docRefSet2TraceTest() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore
+          .collection("col")
+          .document("foo")
+          .set(Collections.singletonMap("foo", "bar"), SetOptions.merge())
+          .get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_SET,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
 
   @Test
-  public void docRefGet() throws Exception {}
+  public void docRefSet3TraceTest() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document("foo").set(new Pojo(1)).get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_SET,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
 
   @Test
-  public void docRefGet2() throws Exception {}
+  public void docRefSet4TraceTest() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document("foo").set(new Pojo(1), SetOptions.merge()).get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_SET,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefUpdate() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore
+          .collection("col")
+          .document("foo")
+          .update(Collections.singletonMap("foo", "bar"))
+          .get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_UPDATE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefUpdate2() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore
+          .collection("col")
+          .document("foo")
+          .update(Collections.singletonMap("foo", "bar"), Precondition.NONE)
+          .get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_UPDATE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefUpdate3() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document("foo").update("key", "value", "key2", "value2").get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_UPDATE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefUpdate4() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore
+          .collection("col")
+          .document("foo")
+          .update(FieldPath.of("key"), "value", FieldPath.of("key2"), "value2")
+          .get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_UPDATE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefUpdate5() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore
+          .collection("col")
+          .document("foo")
+          .update(Precondition.NONE, "key", "value", "key2", "value2")
+          .get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_UPDATE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefUpdate6() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore
+          .collection("col")
+          .document("foo")
+          .update(Precondition.NONE, FieldPath.of("key"), "value", FieldPath.of("key2"), "value2")
+          .get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_UPDATE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefDelete() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document("doc0").delete().get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_DELETE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefDelete2() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document("doc0").delete(Precondition.NONE).get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_DELETE,
+        SPAN_NAME_BATCH_COMMIT,
+        grpcSpanName(COMMIT_RPC_NAME));
+  }
+
+  @Test
+  public void docRefGet() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document("doc0").get().get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_GET,
+        grpcSpanName(BATCH_GET_DOCUMENTS_RPC_NAME));
+  }
+
+  @Test
+  public void docRefGet2() throws Exception {
+    // Make sure the test has a new SpanContext (and TraceId for injection)
+    assertNotNull(customSpanContext);
+
+    // Inject new trace ID
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").document("doc0").get(FieldMask.of("foo")).get();
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    // Read and validate traces
+    fetchAndValidateTraces(
+        customSpanContext.getTraceId(),
+        SPAN_NAME_DOC_REF_GET,
+        grpcSpanName(BATCH_GET_DOCUMENTS_RPC_NAME));
+  }
 
   @Test
   public void docListCollections() throws Exception {}

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
@@ -187,7 +187,7 @@ public class ITE2ETracingTest extends ITBaseTest {
               + ", expectedCallStack[0]="
               + (expectedCallStack.isEmpty() ? "null" : expectedCallStack.get(0)));
       if (expectedCallStack.isEmpty()) {
-        throw new RuntimeException("Input callStack is empty");
+        return false;
       }
       if (spanName(spanId).equals(expectedCallStack.get(0))) {
         // Recursion termination

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore.it;
+
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOpenTelemetryOptions;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.opentelemetry.trace.TraceConfiguration;
+import com.google.cloud.opentelemetry.trace.TraceExporter;
+import com.google.cloud.trace.v1.TraceServiceClient;
+import com.google.common.base.Preconditions;
+import com.google.devtools.cloudtrace.v1.Trace;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ITE2ETracingTest extends ITBaseTest {
+
+  private static final Logger logger = Logger.getLogger(ITBaseTest.class.getName());
+
+  private static final int NUM_TRACE_ID_BYTES = 32;
+
+  private static final int NUM_SPAN_ID_BYTES = 16;
+
+  private static final int GET_TRACE_RETRY_COUNT = 10;
+
+  private static final int GET_TRACE_RETRY_BACKOFF_MILLIS = 1000;
+
+  private static final int TRACE_FORCE_FLUSH_MILLIS = 1000;
+
+  private static final int TRACE_PROVIDER_SHUTDOWN_MILLIS = 1000;
+
+  // Random int generator for trace ID and span ID
+  private static Random random;
+
+  private static TraceExporter traceExporter;
+
+  // Required for reading back traces from Cloud Trace for validation
+  private static TraceServiceClient traceClient_v1;
+
+  private static String rootSpanName;
+  private static Tracer tracer;
+
+  // Required to set custom-root span
+  private static OpenTelemetrySdk openTelemetrySdk;
+
+  private static String projectId;
+
+  private static Firestore firestore;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    projectId = FirestoreOptions.getDefaultProjectId();
+    logger.info("projectId:" + projectId);
+
+    // Set up OTel SDK
+    Resource resource =
+        Resource.getDefault().merge(Resource.builder().put(SERVICE_NAME, "Sparky").build());
+
+    // TODO(jimit) Make it re-usable w/ InMemorySpanExporter
+    traceExporter =
+        TraceExporter.createWithConfiguration(
+            TraceConfiguration.builder().setProjectId(projectId).build());
+
+    openTelemetrySdk =
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    .setResource(resource)
+                    .addSpanProcessor(BatchSpanProcessor.builder(traceExporter).build())
+                    .setSampler(Sampler.alwaysOn())
+                    .build())
+            .build();
+
+    traceClient_v1 = TraceServiceClient.create();
+
+    // Initialize the Firestore DB w/ the OTel SDK
+    FirestoreOptions.Builder optionsBuilder =
+        FirestoreOptions.newBuilder()
+            .setOpenTelemetryOptions(
+                FirestoreOpenTelemetryOptions.newBuilder()
+                    .setOpenTelemetry(openTelemetrySdk)
+                    .setTracingEnabled(true)
+                    .build());
+
+    String namedDb = System.getProperty("FIRESTORE_NAMED_DATABASE");
+    if (namedDb != null) {
+      logger.log(Level.INFO, "Integration test using named database " + namedDb);
+      optionsBuilder = optionsBuilder.setDatabaseId(namedDb);
+    } else {
+      logger.log(Level.INFO, "Integration test using default database.");
+    }
+    firestore = optionsBuilder.build().getService();
+    Preconditions.checkNotNull(
+        firestore,
+        "Error instantiating Firestore. Check that the service account credentials "
+            + "were properly set.");
+    random = new Random();
+  }
+
+  @Before
+  public void before() throws Exception {
+    rootSpanName =
+        String.format("%s%d", this.getClass().getSimpleName(), System.currentTimeMillis());
+    tracer =
+        firestore.getOptions().getOpenTelemetryOptions().getOpenTelemetry().getTracer(rootSpanName);
+  }
+
+  @After
+  public void after() throws Exception {
+    rootSpanName = null;
+    tracer = null;
+  }
+
+  @AfterClass
+  public static void teardown() {
+    traceClient_v1.close();
+    CompletableResultCode completableResultCode =
+        openTelemetrySdk.getSdkTracerProvider().shutdown();
+    completableResultCode.join(TRACE_PROVIDER_SHUTDOWN_MILLIS, TimeUnit.MILLISECONDS);
+    firestore.shutdown();
+  }
+
+  // Generates a random 32-byte hex string
+  private String generateRandomHexString(int numBytes) {
+    StringBuffer newTraceId = new StringBuffer();
+    while (newTraceId.length() < numBytes) {
+      newTraceId.append(Integer.toHexString(random.nextInt()));
+    }
+    return newTraceId.substring(0, numBytes);
+  }
+
+  protected String generateNewTraceId() {
+    return generateRandomHexString(NUM_TRACE_ID_BYTES);
+  }
+
+  // Generates a random 16-byte hex string
+  protected String generateNewSpanId() {
+    return generateRandomHexString(NUM_SPAN_ID_BYTES);
+  }
+
+  // Cloud Trace indexes traces w/ eventual consistency, even when indexing traceId, therefore the
+  // test must retry a few times before the trace is available.
+  protected Trace getTraceWithRetry(String project, String traceId)
+      throws InterruptedException, RuntimeException {
+    int retryCount = GET_TRACE_RETRY_COUNT;
+
+    while (retryCount-- > 0) {
+      try {
+        Trace t = traceClient_v1.getTrace(project, traceId);
+        return t;
+      } catch (NotFoundException notFound) {
+        logger.warning("Trace not found, retrying in " + GET_TRACE_RETRY_BACKOFF_MILLIS + " ms");
+        Thread.sleep(GET_TRACE_RETRY_BACKOFF_MILLIS);
+      }
+    }
+    throw new RuntimeException(
+        "Trace " + traceId + " for project " + project + " not found in Cloud Trace.");
+  }
+
+  // Generates a new SpanContext w/ random traceId,spanId
+  protected SpanContext getNewSpanContext() {
+    String traceId = generateNewTraceId();
+    String spanId = generateNewSpanId();
+    logger.info("traceId=" + traceId + ", spanId=" + spanId);
+
+    return SpanContext.create(traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+  }
+
+  protected void waitForTracesToComplete() throws Exception {
+    CompletableResultCode completableResultCode =
+        openTelemetrySdk.getSdkTracerProvider().forceFlush();
+    completableResultCode.join(TRACE_FORCE_FLUSH_MILLIS, TimeUnit.MILLISECONDS);
+
+    // We need to call `firestore.close()` because that will also close the
+    // gRPC channel and hence force the gRPC instrumentation library to flush
+    // its spans.
+    firestore.close();
+  }
+
+  @Test
+  // Trace an Aggregation.Get request
+  public void basicTraceTestWithCustomRootSpan() throws Exception {
+    SpanContext newCtx = getNewSpanContext();
+
+    // Execute the DB operation in the context of the custom root span.
+    Span rootSpan =
+        tracer
+            .spanBuilder(rootSpanName)
+            .setParent(Context.root().with(Span.wrap(newCtx)))
+            .startSpan();
+    try (Scope ss = rootSpan.makeCurrent()) {
+      firestore.collection("col").count().get().get();
+    } finally {
+      rootSpan.end();
+    }
+
+    // Ingest traces to Cloud Trace
+    waitForTracesToComplete();
+
+    String traceId = newCtx.getTraceId();
+    Trace t = getTraceWithRetry(projectId, traceId);
+    assertEquals(t.getTraceId(), traceId);
+    assertEquals(t.getSpans(0).getName(), rootSpanName);
+    assertEquals(t.getSpans(1).getName(), "AggregationQuery.Get");
+  }
+}


### PR DESCRIPTION
test: End-to-End Integration Test for Client-side Tracing in Firestore Java Server SDK using OpenTelemetry SDK and Cloud Trace Exporter against Cloud Trace. 

The test is parameterized to run all the cases with and without the use of a Global OpenTelemetry SDK instance.

In order to run these tests, the test-run user must have permissions listed in https://cloud.google.com/trace/docs/iam#trace-roles so the test can ingest into and read traces from Cloud Trace

Fixes #1604  ☕️