### PR TITLE
chore: make the owlbot postprocessor check non-required

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -16,7 +16,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Integration'
       - 'Kokoro - Test: Integration Against Named DB'
       - cla/google
-      - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
       - javadoc


### PR DESCRIPTION
We will soon disable the Owlbot postprocessor. This is part of the effort to enable hermetic generation in this repo ([context](https://docs.google.com/document/d/1wrpyBtphdenM3BNelcnpBKGADYrGJUo686HXvSA0h-0/edit?pli=1&tab=t.0#bookmark=kix.914gcjvdwt3u))