### PR TITLE
ci: simplify java 8 unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,10 +51,6 @@ jobs:
         # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
         run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
         shell: bash
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: temurin
       - run: .kokoro/build.sh
         env:
           JOB_TYPE: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [8, 11, 17, 21]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
@@ -36,24 +36,6 @@ jobs:
     - run: .kokoro/build.sh
       env:
         JOB_TYPE: test
-  units-java8:
-    # Building using Java 17 and run the tests with Java 8 runtime
-    name: "units (8)"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 8
-          distribution: temurin
-      - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
-        # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
-        # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
-        run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
-        shell: bash
-      - run: .kokoro/build.sh
-        env:
-          JOB_TYPE: test
   windows:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
The Java 8 unit test special setup ("compile in Java 17 and run tests in Java 8") was introduced by the template change for java-spanner https://github.com/googleapis/java-spanner/pull/1870. This java-firestore repository does not need the special setup.

@milaGGL 