### PR TITLE
Fix Instant-record merge

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BeanMapper.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/BeanMapper.java
@@ -26,6 +26,7 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -148,13 +149,13 @@ abstract class BeanMapper<T> {
   void applyFieldAnnotations(Field field) {
     if (field.isAnnotationPresent(ServerTimestamp.class)) {
       Class<?> fieldType = field.getType();
-      if (fieldType != Date.class && fieldType != Timestamp.class) {
+      if (fieldType != Date.class && fieldType != Timestamp.class && fieldType != Instant.class) {
         throw new IllegalArgumentException(
             "Field "
                 + field.getName()
                 + " is annotated with @ServerTimestamp but is "
                 + fieldType
-                + " instead of Date or Timestamp.");
+                + " instead of Date, Timestamp, or Instant.");
       }
       serverTimestamps.add(propertyName(field));
     }


### PR DESCRIPTION
This is a fix for the rebase of this branch onto main.
In [a separate PR](https://github.com/googleapis/java-firestore/pull/1586), I have changed the method `CustomClassMapper.applyFieldAnnotations`, which is being moved in the record branch to class `BeanMapper`.
This PR applies the change to that method, which was lost in the rebase, in its new location.
