### PR TITLE
chore: remove unused image tag in .OwlBot-hermetic.yaml

### DIFF
--- a/.github/.OwlBot-hermetic.yaml
+++ b/.github/.OwlBot-hermetic.yaml
@@ -1,6 +1,3 @@
-docker:
-  image: "gcr.io/cloud-devrel-public-resources/owlbot-java:latest"
-
 deep-remove-regex:
 - "/grpc-google-.*/src"
 - "/proto-google-.*/src"


### PR DESCRIPTION
This removes the unused image tag in this file. Part of the cleanup after enabling Hermetic Library generation in this repo.