### PR TITLE
Fix: fix clirr check failure

### DIFF
--- a/google-cloud-firestore/clirr-ignored-differences.xml
+++ b/google-cloud-firestore/clirr-ignored-differences.xml
@@ -303,7 +303,7 @@
   <!-- Reverted a change to make CustomClassMapper public -->
   <difference>
     <differenceType>8001</differenceType>
-    <className>com.google.cloud.firestore.encoding.CustomClassMapper</className>
+    <className>com/google/cloud/firestore/encoding/CustomClassMapper</className>
     <to>*</to>
   </difference>
 </differences>

--- a/google-cloud-firestore/clirr-ignored-differences.xml
+++ b/google-cloud-firestore/clirr-ignored-differences.xml
@@ -299,4 +299,11 @@
     <className>com/google/cloud/firestore/collection/StandardComparator</className>
     <to>*</to>
   </difference>
+
+  <!-- Reverted a change to make CustomClassMapper public -->
+  <difference>
+    <differenceType>8001</differenceType>
+    <className>com.google.cloud.firestore.encoding.CustomClassMapper</className>
+    <to>*</to>
+  </difference>
 </differences>


### PR DESCRIPTION
A feature branch that marks CustomClassMapper public has been reverted, and this is causing clirr check to fail.