### PR TITLE
feat: introduce `java.time` variables and methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-firestore</artifactId>
-  <version>3.29.0</version>
+  <version>3.29.1</version>
 </dependency>
 
 ```

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreImpl.java
@@ -16,11 +16,13 @@
 
 package com.google.cloud.firestore;
 
+import static com.google.api.gax.util.TimeConversionUtils.toThreetenDuration;
 import static com.google.cloud.firestore.telemetry.TraceUtil.*;
 
 import com.google.api.core.ApiClock;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.NanoClock;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamObserver;
@@ -52,7 +54,6 @@ import java.util.Map;
 import java.util.Random;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.threeten.bp.Duration;
 
 /**
  * Main implementation of the Firestore client. This is the entry point for all Firestore
@@ -500,9 +501,16 @@ class FirestoreImpl implements Firestore, FirestoreRpcContext<FirestoreImpl> {
     return firestoreClient;
   }
 
+  /** This method is obsolete. Use {@link #getTotalRequestTimeoutDuration()} instead. */
+  @ObsoleteApi("Use getTotalRequestTimeoutDuration() instead")
   @Override
-  public Duration getTotalRequestTimeout() {
-    return firestoreOptions.getRetrySettings().getTotalTimeout();
+  public org.threeten.bp.Duration getTotalRequestTimeout() {
+    return toThreetenDuration(getTotalRequestTimeoutDuration());
+  }
+
+  @Override
+  public java.time.Duration getTotalRequestTimeoutDuration() {
+    return firestoreOptions.getRetrySettings().getTotalTimeoutDuration();
   }
 
   @Override

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreRpcContext.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreRpcContext.java
@@ -16,10 +16,13 @@
 
 package com.google.cloud.firestore;
 
+import static com.google.api.gax.util.TimeConversionUtils.toJavaTimeDuration;
+
 import com.google.api.core.ApiClock;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.api.core.InternalExtensionOnly;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.rpc.BidiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientStream;
@@ -27,7 +30,6 @@ import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.firestore.spi.v1.FirestoreRpc;
-import org.threeten.bp.Duration;
 
 @InternalApi
 @InternalExtensionOnly
@@ -41,7 +43,13 @@ interface FirestoreRpcContext<FS extends Firestore> {
 
   FirestoreRpc getClient();
 
-  Duration getTotalRequestTimeout();
+  /** This method is obsolete. Use {@link #getTotalRequestTimeoutDuration()} instead. */
+  @ObsoleteApi("Use getTotalRequestTimeoutDuration() instead")
+  org.threeten.bp.Duration getTotalRequestTimeout();
+
+  default java.time.Duration getTotalRequestTimeoutDuration() {
+    return toJavaTimeDuration(getTotalRequestTimeout());
+  }
 
   ApiClock getClock();
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/StreamableQuery.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/StreamableQuery.java
@@ -39,6 +39,7 @@ import com.google.firestore.v1.RunQueryRequest;
 import com.google.firestore.v1.RunQueryResponse;
 import com.google.protobuf.ByteString;
 import io.grpc.Status;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,7 +47,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.threeten.bp.Duration;
 
 /**
  * Represents a query whose results can be streamed. If the stream fails with a retryable error,
@@ -452,7 +452,7 @@ public abstract class StreamableQuery<SnapshotType> {
     }
 
     Duration duration = Duration.ofNanos(rpcContext.getClock().nanoTime() - startTimeNanos);
-    return duration.compareTo(rpcContext.getTotalRequestTimeout()) < 0;
+    return duration.compareTo(rpcContext.getTotalRequestTimeoutDuration()) < 0;
   }
 
   /** Verifies whether the given exception is retryable based on the RunQuery configuration. */

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/telemetry/CompositeApiTracer.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/telemetry/CompositeApiTracer.java
@@ -16,13 +16,14 @@
 
 package com.google.cloud.firestore.telemetry;
 
+import static com.google.api.gax.util.TimeConversionUtils.toJavaTimeDuration;
+
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.BaseApiTracer;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.threeten.bp.Duration;
 
 /** Combines multiple {@link ApiTracer}s into a single {@link ApiTracer}. */
 class CompositeApiTracer extends BaseApiTracer {
@@ -83,8 +84,8 @@ class CompositeApiTracer extends BaseApiTracer {
   }
 
   @Override
-  public void attemptFailed(Throwable error, Duration delay) {
-    children.forEach(child -> child.attemptFailed(error, delay));
+  public void attemptFailed(Throwable error, org.threeten.bp.Duration delay) {
+    attemptFailedDuration(error, toJavaTimeDuration(delay));
   }
 
   @Override

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/telemetry/EnabledTraceUtil.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/telemetry/EnabledTraceUtil.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.firestore.telemetry;
 
+import static com.google.api.gax.util.TimeConversionUtils.toJavaTimeDuration;
+
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
@@ -94,12 +96,16 @@ public class EnabledTraceUtil implements TraceUtil {
     return new OpenTelemetryGrpcChannelConfigurator();
   }
 
+  String durationString(org.threeten.bp.Duration duration) {
+    return durationStringDuration(toJavaTimeDuration(duration));
+  }
+
   // Returns a JSON String representation of the given duration. The JSON representation for a
   // Duration is a String that
   // ends in `s` to indicate seconds and is preceded by the number of seconds, with nanoseconds
   // expressed as fractional
   // seconds.
-  String durationString(org.threeten.bp.Duration duration) {
+  String durationStringDuration(java.time.Duration duration) {
     int nanos = duration.getNano();
     long seconds = duration.getSeconds();
     int numLeadingZeros = 9;

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/telemetry/EnabledTraceUtil.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/telemetry/EnabledTraceUtil.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.firestore.telemetry;
 
-import static com.google.api.gax.util.TimeConversionUtils.toJavaTimeDuration;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
@@ -96,16 +95,12 @@ public class EnabledTraceUtil implements TraceUtil {
     return new OpenTelemetryGrpcChannelConfigurator();
   }
 
-  String durationString(org.threeten.bp.Duration duration) {
-    return durationStringDuration(toJavaTimeDuration(duration));
-  }
-
   // Returns a JSON String representation of the given duration. The JSON representation for a
   // Duration is a String that
   // ends in `s` to indicate seconds and is preceded by the number of seconds, with nanoseconds
   // expressed as fractional
   // seconds.
-  String durationStringDuration(java.time.Duration duration) {
+  String durationString(java.time.Duration duration) {
     int nanos = duration.getNano();
     long seconds = duration.getSeconds();
     int numLeadingZeros = 9;
@@ -336,10 +331,12 @@ public class EnabledTraceUtil implements TraceUtil {
               Attributes.builder()
                   .put(
                       ATTRIBUTE_SERVICE_PREFIX + "settings.retry_settings.initial_retry_delay",
-                      durationString(firestoreOptions.getRetrySettings().getInitialRetryDelay()))
+                      durationString(
+                          firestoreOptions.getRetrySettings().getInitialRetryDelayDuration()))
                   .put(
                       ATTRIBUTE_SERVICE_PREFIX + "settings.retry_settings.max_retry_delay",
-                      durationString(firestoreOptions.getRetrySettings().getMaxRetryDelay()))
+                      durationString(
+                          firestoreOptions.getRetrySettings().getMaxRetryDelayDuration()))
                   .put(
                       ATTRIBUTE_SERVICE_PREFIX + "settings.retry_settings.retry_delay_multiplier",
                       String.valueOf(firestoreOptions.getRetrySettings().getRetryDelayMultiplier()))
@@ -348,16 +345,18 @@ public class EnabledTraceUtil implements TraceUtil {
                       String.valueOf(firestoreOptions.getRetrySettings().getMaxAttempts()))
                   .put(
                       ATTRIBUTE_SERVICE_PREFIX + "settings.retry_settings.initial_rpc_timeout",
-                      durationString(firestoreOptions.getRetrySettings().getInitialRpcTimeout()))
+                      durationString(
+                          firestoreOptions.getRetrySettings().getInitialRpcTimeoutDuration()))
                   .put(
                       ATTRIBUTE_SERVICE_PREFIX + "settings.retry_settings.max_rpc_timeout",
-                      durationString(firestoreOptions.getRetrySettings().getMaxRpcTimeout()))
+                      durationString(
+                          firestoreOptions.getRetrySettings().getMaxRpcTimeoutDuration()))
                   .put(
                       ATTRIBUTE_SERVICE_PREFIX + "settings.retry_settings.rpc_timeout_multiplier",
                       String.valueOf(firestoreOptions.getRetrySettings().getRpcTimeoutMultiplier()))
                   .put(
                       ATTRIBUTE_SERVICE_PREFIX + "settings.retry_settings.total_timeout",
-                      durationString(firestoreOptions.getRetrySettings().getTotalTimeout()))
+                      durationString(firestoreOptions.getRetrySettings().getTotalTimeoutDuration()))
                   .build());
     }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/telemetry/EnabledTraceUtil.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/telemetry/EnabledTraceUtil.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.firestore.telemetry;
 
-
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
@@ -71,6 +71,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,14 +89,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Stubber;
-import org.threeten.bp.Duration;
 
 public final class LocalFirestoreHelper {
 
   protected static RetrySettings IMMEDIATE_RETRY_SETTINGS =
       RetrySettings.newBuilder()
-          .setInitialRetryDelay(Duration.ZERO)
-          .setMaxRetryDelay(Duration.ZERO)
+          .setInitialRetryDelayDuration(Duration.ZERO)
+          .setMaxRetryDelayDuration(Duration.ZERO)
           .setRetryDelayMultiplier(1)
           .setJittered(false)
           .build();

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryCountTest.java
@@ -41,6 +41,7 @@ import com.google.firestore.v1.RunAggregationQueryRequest;
 import com.google.firestore.v1.RunAggregationQueryResponse;
 import com.google.firestore.v1.StructuredQuery;
 import io.grpc.Status;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -50,7 +51,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.threeten.bp.Duration;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueryCountTest {
@@ -70,7 +70,7 @@ public class QueryCountTest {
 
   @Before
   public void before() {
-    doReturn(Duration.ZERO).when(firestoreMock).getTotalRequestTimeout();
+    doReturn(Duration.ZERO).when(firestoreMock).getTotalRequestTimeoutDuration();
     query = firestoreMock.collection(COLLECTION_ID);
   }
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryCountTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryCountTest.java
@@ -230,7 +230,7 @@ public class QueryCountTest {
   public void
       shouldRetryIfExceptionIsFirestoreExceptionWithRetryableStatusWithInfiniteTimeoutWindow()
           throws Exception {
-    doReturn(Duration.ZERO).when(firestoreMock).getTotalRequestTimeout();
+    doReturn(Duration.ZERO).when(firestoreMock).getTotalRequestTimeoutDuration();
     doAnswer(countQueryResponse(new FirestoreException("reason", Status.INTERNAL)))
         .doAnswer(countQueryResponse(42))
         .when(firestoreMock)
@@ -245,7 +245,7 @@ public class QueryCountTest {
   @Test
   public void shouldRetryIfExceptionIsFirestoreExceptionWithRetryableStatusWithinTimeoutWindow()
       throws Exception {
-    doReturn(Duration.ofDays(999)).when(firestoreMock).getTotalRequestTimeout();
+    doReturn(Duration.ofDays(999)).when(firestoreMock).getTotalRequestTimeoutDuration();
     doAnswer(countQueryResponse(new FirestoreException("reason", Status.INTERNAL)))
         .doAnswer(countQueryResponse(42))
         .when(firestoreMock)
@@ -267,7 +267,7 @@ public class QueryCountTest {
         .doReturn(TimeUnit.SECONDS.toNanos(30))
         .when(clockMock)
         .nanoTime();
-    doReturn(Duration.ofSeconds(5)).when(firestoreMock).getTotalRequestTimeout();
+    doReturn(Duration.ofSeconds(5)).when(firestoreMock).getTotalRequestTimeoutDuration();
     doAnswer(countQueryResponse(new FirestoreException("reason", Status.INTERNAL)))
         .doAnswer(countQueryResponse(42))
         .when(firestoreMock)

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -67,6 +67,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.Status;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -82,7 +83,6 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.threeten.bp.Duration;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueryTest {
@@ -123,7 +123,7 @@ public class QueryTest {
   public void before() {
     clock = new MockClock();
     doReturn(clock).when(firestoreMock).getClock();
-    doReturn(Duration.ZERO).when(firestoreMock).getTotalRequestTimeout();
+    doReturn(Duration.ZERO).when(firestoreMock).getTotalRequestTimeoutDuration();
 
     query = firestoreMock.collection(COLLECTION_ID);
   }
@@ -1130,7 +1130,7 @@ public class QueryTest {
 
   @Test
   public void doesNotRetryWithTimeout() {
-    doReturn(Duration.ofMinutes(1)).when(firestoreMock).getTotalRequestTimeout();
+    doReturn(Duration.ofMinutes(1)).when(firestoreMock).getTotalRequestTimeoutDuration();
 
     doAnswer(
             invocation -> {

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java
@@ -84,6 +84,7 @@ import com.google.firestore.v1.RunQueryRequest;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -106,7 +107,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class ITSystemTest extends ITBaseTest {
@@ -2281,9 +2281,9 @@ public class ITSystemTest extends ITBaseTest {
         FirestoreOptions.newBuilder()
             .setRetrySettings(
                 RetrySettings.newBuilder()
-                    .setMaxRpcTimeout(Duration.ofMillis(1))
-                    .setTotalTimeout(Duration.ofMillis(1))
-                    .setInitialRpcTimeout(Duration.ofMillis(1))
+                    .setMaxRpcTimeoutDuration(Duration.ofMillis(1))
+                    .setTotalTimeoutDuration(Duration.ofMillis(1))
+                    .setInitialRpcTimeoutDuration(Duration.ofMillis(1))
                     .build())
             .build();
     firestore = firestoreOptions.getService();

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/telemetry/EnabledTraceUtilTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/telemetry/EnabledTraceUtilTest.java
@@ -22,9 +22,9 @@ import com.google.cloud.firestore.FirestoreOptions;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import java.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.Duration;
 
 public class EnabledTraceUtilTest {
   @Before
@@ -138,63 +138,63 @@ public class EnabledTraceUtilTest {
   public void durationString() {
     EnabledTraceUtil traceUtil = defaultEnabledTraceUtil();
     Duration duration = Duration.ofSeconds(2, 9);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("2.000000009s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("2.000000009s");
 
     duration = Duration.ofSeconds(3, 98);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("3.000000098s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("3.000000098s");
 
     duration = Duration.ofSeconds(4, 987);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("4.000000987s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("4.000000987s");
 
     duration = Duration.ofSeconds(5, 9876);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("5.000009876s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("5.000009876s");
 
     duration = Duration.ofSeconds(6, 98765);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("6.000098765s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("6.000098765s");
 
     duration = Duration.ofSeconds(7, 987654);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("7.000987654s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("7.000987654s");
 
     duration = Duration.ofSeconds(8, 9876543);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("8.009876543s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("8.009876543s");
 
     duration = Duration.ofSeconds(9, 98765432);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("9.098765432s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("9.098765432s");
 
     duration = Duration.ofSeconds(10, 987654321);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("10.987654321s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("10.987654321s");
 
     duration = Duration.ofSeconds(1, 0);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.0s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.0s");
 
     duration = Duration.ofSeconds(1, 1);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.000000001s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.000000001s");
 
     duration = Duration.ofSeconds(1, 10);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.00000001s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.00000001s");
 
     duration = Duration.ofSeconds(1, 100);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.0000001s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.0000001s");
 
     duration = Duration.ofSeconds(1, 1_000);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.000001s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.000001s");
 
     duration = Duration.ofSeconds(1, 10_000);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.00001s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.00001s");
 
     duration = Duration.ofSeconds(1, 100_000);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.0001s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.0001s");
 
     duration = Duration.ofSeconds(1, 1_000_000);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.001s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.001s");
 
     duration = Duration.ofSeconds(1, 10_000_000);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.01s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.01s");
 
     duration = Duration.ofSeconds(1, 100_000_000);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.1s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.1s");
 
     duration = Duration.ofSeconds(1, 100_000_001);
-    assertThat(traceUtil.durationString(duration)).isEqualTo("1.100000001s");
+    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.100000001s");
   }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/telemetry/EnabledTraceUtilTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/telemetry/EnabledTraceUtilTest.java
@@ -138,63 +138,63 @@ public class EnabledTraceUtilTest {
   public void durationString() {
     EnabledTraceUtil traceUtil = defaultEnabledTraceUtil();
     Duration duration = Duration.ofSeconds(2, 9);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("2.000000009s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("2.000000009s");
 
     duration = Duration.ofSeconds(3, 98);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("3.000000098s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("3.000000098s");
 
     duration = Duration.ofSeconds(4, 987);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("4.000000987s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("4.000000987s");
 
     duration = Duration.ofSeconds(5, 9876);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("5.000009876s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("5.000009876s");
 
     duration = Duration.ofSeconds(6, 98765);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("6.000098765s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("6.000098765s");
 
     duration = Duration.ofSeconds(7, 987654);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("7.000987654s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("7.000987654s");
 
     duration = Duration.ofSeconds(8, 9876543);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("8.009876543s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("8.009876543s");
 
     duration = Duration.ofSeconds(9, 98765432);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("9.098765432s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("9.098765432s");
 
     duration = Duration.ofSeconds(10, 987654321);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("10.987654321s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("10.987654321s");
 
     duration = Duration.ofSeconds(1, 0);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.0s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.0s");
 
     duration = Duration.ofSeconds(1, 1);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.000000001s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.000000001s");
 
     duration = Duration.ofSeconds(1, 10);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.00000001s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.00000001s");
 
     duration = Duration.ofSeconds(1, 100);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.0000001s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.0000001s");
 
     duration = Duration.ofSeconds(1, 1_000);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.000001s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.000001s");
 
     duration = Duration.ofSeconds(1, 10_000);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.00001s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.00001s");
 
     duration = Duration.ofSeconds(1, 100_000);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.0001s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.0001s");
 
     duration = Duration.ofSeconds(1, 1_000_000);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.001s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.001s");
 
     duration = Duration.ofSeconds(1, 10_000_000);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.01s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.01s");
 
     duration = Duration.ofSeconds(1, 100_000_000);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.1s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.1s");
 
     duration = Duration.ofSeconds(1, 100_000_001);
-    assertThat(traceUtil.durationStringDuration(duration)).isEqualTo("1.100000001s");
+    assertThat(traceUtil.durationString(duration)).isEqualTo("1.100000001s");
   }
 }


### PR DESCRIPTION
This PR introduces `java.time` alternatives to existing `org.threeten.bp.*` methods, as well as switching internal variables (if any) to `java.time`

The main constraint is to keep the changes backwards compatible, so for each existing threeten method "`method1(org.threeten.bp.Duration)`" we will add an alternative with a _Duration_ (or _Timestamp_ when applicable) suffix: "`method1Duration(java.time.Duration)`".

For most cases, the implementation will be held in the `java.time` method and the old threeten method will just delegate the call to it. However, for the case of abstract classes, the implementation will be kept in the threeten method to avoid breaking changes (i.e. users that already overloaded the method in their user code).