### PR TITLE
chore: CODEOWNERS for generated Java code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,14 @@
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
 **/*.java               @googleapis/api-firestore @googleapis/firestore-dpe
 
+# For generated Java code
+proto-*/                    @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
+grpc-*/                     @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
+# Generated code pattern in google-cloud-firestore and google-cloud-firestore-admin
+**/*Client.java             @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
+**/*Settings.java           @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
+**/*ClientHttpJsonTest.java @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
+**/*ClientTest.java         @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers


### PR DESCRIPTION
This pattern for generated Java code allows us (Cloud Java / yoshi-java) to merge the pull requests without additional reviews.

b/379670583
