### PR TITLE
Pipeline Expressions Refactor

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UserDataConverter.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/UserDataConverter.java
@@ -41,6 +41,8 @@ import javax.annotation.Nullable;
 
 /** Converts user input into the Firestore Value representation. */
 class UserDataConverter {
+
+  static final Value NULL_VALUE = Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
   private static final Logger LOGGER = Logger.getLogger(UserDataConverter.class.getName());
 
   /** Controls the behavior for field deletes. */
@@ -120,8 +122,9 @@ class UserDataConverter {
               + " as an argument at field '%s'.",
           path);
       return null;
+
     } else if (sanitizedObject == null) {
-      return Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
+      return NULL_VALUE;
     } else if (sanitizedObject instanceof String) {
       return Value.newBuilder().setStringValue((String) sanitizedObject).build();
     } else if (sanitizedObject instanceof Integer) {

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Accumulator.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Accumulator.java
@@ -17,12 +17,18 @@
 package com.google.cloud.firestore.pipeline.expressions;
 
 import com.google.api.core.BetaApi;
+import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public interface Accumulator extends Expr {
+public abstract class Accumulator extends Function {
+
+  protected Accumulator(String name, ImmutableList<? extends Expr> params) {
+    super(name, params);
+  }
+
   @BetaApi
   @Override
-  default ExprWithAlias<Accumulator> as(String fieldName) {
+  public ExprWithAlias<Accumulator> as(String fieldName) {
     return new ExprWithAlias<>(this, fieldName);
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/And.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/And.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 @BetaApi
-public final class And extends Function implements FilterCondition {
+public final class And extends FilterCondition {
   @InternalApi
   And(List<FilterCondition> conditions) {
     super("and", ImmutableList.copyOf(conditions));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ArrayContains.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ArrayContains.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class ArrayContains extends Function implements FilterCondition {
+public final class ArrayContains extends FilterCondition {
   @InternalApi
   ArrayContains(Expr array, Expr element) {
     super(

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ArrayContainsAll.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ArrayContainsAll.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 @BetaApi
-public final class ArrayContainsAll extends Function implements FilterCondition {
+public final class ArrayContainsAll extends FilterCondition {
   @InternalApi
   ArrayContainsAll(Expr array, List<Expr> elements) {
     super("array_contains_all", ImmutableList.of(array, new ListOfExprs(elements)));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ArrayContainsAny.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ArrayContainsAny.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 @BetaApi
-public final class ArrayContainsAny extends Function implements FilterCondition {
+public final class ArrayContainsAny extends FilterCondition {
   @InternalApi
   ArrayContainsAny(Expr array, List<Expr> elements) {
     super("array_contains_any", ImmutableList.of(array, new ListOfExprs(elements)));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Avg.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Avg.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Avg extends Function implements Accumulator {
+public final class Avg extends Accumulator {
   @InternalApi
   Avg(Expr value, boolean distinct) {
     super("avg", ImmutableList.of(value));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Constant.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Constant.java
@@ -25,13 +25,14 @@ import com.google.cloud.firestore.Blob;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.FieldValue;
 import com.google.cloud.firestore.GeoPoint;
+import com.google.common.collect.ImmutableMap;
 import com.google.firestore.v1.Value;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
 
 @BetaApi
-public final class Constant implements Expr {
+public final class Constant extends Expr {
   private final Object value;
 
   Constant(Object value) {
@@ -137,8 +138,8 @@ public final class Constant implements Expr {
     return new Constant(FieldValue.vector(value));
   }
 
-  @InternalApi
-  public Value toProto() {
+  @Override
+  Value toProto() {
     return encodeValue(value);
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Constant.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Constant.java
@@ -33,6 +33,9 @@ import java.util.Map;
 
 @BetaApi
 public final class Constant extends Expr {
+
+  static final Constant NULL = new Constant(null);
+
   private final Object value;
 
   Constant(Object value) {
@@ -86,16 +89,14 @@ public final class Constant extends Expr {
 
   @InternalApi
   public static Constant nullValue() {
-    return new Constant(null);
+    return NULL;
   }
 
   @BetaApi
   static Constant of(Object value) {
     if (value == null) {
-      return new Constant(null);
-    }
-
-    if (value instanceof String) {
+      return NULL;
+    } else if (value instanceof String) {
       return of((String) value);
     } else if (value instanceof Number) {
       return of((Number) value);
@@ -113,23 +114,25 @@ public final class Constant extends Expr {
       return of((DocumentReference) value);
     } else if (value instanceof Value) {
       return of((Value) value);
+    } else if (value instanceof Constant) {
+      return (Constant) value;
     } else {
       throw new IllegalArgumentException("Unknown type: " + value);
     }
   }
 
   @BetaApi
-  public static <T> Constant of(Iterable<T> value) {
+  public static Constant of(Iterable<?> value) {
     return new Constant(value);
   }
 
   @BetaApi
-  public static <T> Constant of(T[] value) {
+  public static Constant of(Object[] value) {
     return new Constant(Arrays.asList(value.clone())); // Convert array to list
   }
 
   @BetaApi
-  public static <T> Constant of(Map<String, T> value) {
+  public static Constant of(Map<String, ?> value) {
     return new Constant(value);
   }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Count.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Count.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import javax.annotation.Nonnull;
 
 @BetaApi
-public final class Count extends Function implements Accumulator {
+public final class Count extends Accumulator {
   @InternalApi
   Count(@Nonnull Expr value) {
     super("count", ImmutableList.of(value));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/CountIf.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/CountIf.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class CountIf extends Function implements Accumulator {
+public final class CountIf extends Accumulator {
   @InternalApi
   CountIf(Expr value, boolean distinct) {
     super("countif", (value != null) ? ImmutableList.of(value) : ImmutableList.of());

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/EndsWith.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/EndsWith.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class EndsWith extends Function implements FilterCondition {
+public final class EndsWith extends FilterCondition {
   @InternalApi
   EndsWith(Expr expr, Expr postfix) {
     super("ends_with", ImmutableList.of(expr, postfix));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Eq.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Eq.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Eq extends Function implements FilterCondition {
+public final class Eq extends FilterCondition {
   @InternalApi
   Eq(Expr left, Expr right) {
     super("eq", ImmutableList.of(left, right == null ? Constant.nullValue() : right));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Exists.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Exists.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Exists extends Function implements FilterCondition {
+public final class Exists extends FilterCondition {
   @InternalApi
   Exists(Expr expr) {
     super("exists", ImmutableList.of(expr));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Expr.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Expr.java
@@ -19,6 +19,8 @@ package com.google.cloud.firestore.pipeline.expressions;
 import static com.google.cloud.firestore.pipeline.expressions.FunctionUtils.toExprList;
 
 import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.firestore.v1.Value;
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,7 +42,11 @@ import java.util.List;
  * method calls to create complex expressions.
  */
 @BetaApi
-public interface Expr {
+public abstract class Expr {
+
+  /** Constructor is package-private to prevent extension. */
+  Expr() {
+  }
 
   // Arithmetic Operators
 
@@ -58,7 +64,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the addition operation.
    */
   @BetaApi
-  default Add add(Expr other) {
+  public final Add add(Expr other) {
     return new Add(this, other);
   }
 
@@ -76,7 +82,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the addition operation.
    */
   @BetaApi
-  default Add add(Object other) {
+  public final Add add(Object other) {
     return new Add(this, Constant.of(other));
   }
 
@@ -94,7 +100,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the subtraction operation.
    */
   @BetaApi
-  default Subtract subtract(Expr other) {
+  public final Subtract subtract(Expr other) {
     return new Subtract(this, other);
   }
 
@@ -112,7 +118,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the subtraction operation.
    */
   @BetaApi
-  default Subtract subtract(Object other) {
+  public final Subtract subtract(Object other) {
     return new Subtract(this, Constant.of(other));
   }
 
@@ -130,7 +136,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the multiplication operation.
    */
   @BetaApi
-  default Multiply multiply(Expr other) {
+  public final Multiply multiply(Expr other) {
     return new Multiply(this, other);
   }
 
@@ -148,7 +154,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the multiplication operation.
    */
   @BetaApi
-  default Multiply multiply(Object other) {
+  public final Multiply multiply(Object other) {
     return new Multiply(this, Constant.of(other));
   }
 
@@ -166,7 +172,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the division operation.
    */
   @BetaApi
-  default Divide divide(Expr other) {
+  public final Divide divide(Expr other) {
     return new Divide(this, other);
   }
 
@@ -184,7 +190,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the division operation.
    */
   @BetaApi
-  default Divide divide(Object other) {
+  public final Divide divide(Object other) {
     return new Divide(this, Constant.of(other));
   }
 
@@ -202,7 +208,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the modulo operation.
    */
   @BetaApi
-  default Mod mod(Expr other) {
+  public final Mod mod(Expr other) {
     return new Mod(this, other);
   }
 
@@ -220,7 +226,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the modulo operation.
    */
   @BetaApi
-  default Mod mod(Object other) {
+  public final Mod mod(Object other) {
     return new Mod(this, Constant.of(other));
   }
 
@@ -440,7 +446,7 @@ public interface Expr {
    * @param other The other expression to compare with.
    * @return A new {@code Expr} representing the logical max operation.
    */
-  default LogicalMax logicalMax(Expr other) {
+  public final LogicalMax logicalMax(Expr other) {
     return new LogicalMax(this, other);
   }
 
@@ -461,7 +467,7 @@ public interface Expr {
    * @param other The constant value to compare with.
    * @return A new {@code Expr} representing the logical max operation.
    */
-  default LogicalMax logicalMax(Object other) {
+  public final LogicalMax logicalMax(Object other) {
     return new LogicalMax(this, Constant.of(other));
   }
 
@@ -482,7 +488,7 @@ public interface Expr {
    * @param other The other expression to compare with.
    * @return A new {@code Expr} representing the logical min operation.
    */
-  default LogicalMin logicalMin(Expr other) {
+  public final LogicalMin logicalMin(Expr other) {
     return new LogicalMin(this, other);
   }
 
@@ -503,7 +509,7 @@ public interface Expr {
    * @param other The constant value to compare with.
    * @return A new {@code Expr} representing the logical min operation.
    */
-  default LogicalMin logicalMin(Object other) {
+  public final LogicalMin logicalMin(Object other) {
     return new LogicalMin(this, Constant.of(other));
   }
 
@@ -523,7 +529,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the equality comparison.
    */
   @BetaApi
-  default Eq eq(Expr other) {
+  public final Eq eq(Expr other) {
     return new Eq(this, other);
   }
 
@@ -541,7 +547,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the equality comparison.
    */
   @BetaApi
-  default Eq eq(Object other) {
+  public final Eq eq(Object other) {
     return new Eq(this, Constant.of(other));
   }
 
@@ -559,7 +565,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the inequality comparison.
    */
   @BetaApi
-  default Neq neq(Expr other) {
+  public final Neq neq(Expr other) {
     return new Neq(this, other);
   }
 
@@ -577,7 +583,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the inequality comparison.
    */
   @BetaApi
-  default Neq neq(Object other) {
+  public final Neq neq(Object other) {
     return new Neq(this, Constant.of(other));
   }
 
@@ -595,7 +601,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the greater than comparison.
    */
   @BetaApi
-  default Gt gt(Expr other) {
+  public final Gt gt(Expr other) {
     return new Gt(this, other);
   }
 
@@ -613,7 +619,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the greater than comparison.
    */
   @BetaApi
-  default Gt gt(Object other) {
+  public final Gt gt(Object other) {
     return new Gt(this, Constant.of(other));
   }
 
@@ -632,7 +638,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the greater than or equal to comparison.
    */
   @BetaApi
-  default Gte gte(Expr other) {
+  public final Gte gte(Expr other) {
     return new Gte(this, other);
   }
 
@@ -651,7 +657,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the greater than or equal to comparison.
    */
   @BetaApi
-  default Gte gte(Object other) {
+  public final Gte gte(Object other) {
     return new Gte(this, Constant.of(other));
   }
 
@@ -669,7 +675,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the less than comparison.
    */
   @BetaApi
-  default Lt lt(Expr other) {
+  public final Lt lt(Expr other) {
     return new Lt(this, other);
   }
 
@@ -687,7 +693,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the less than comparison.
    */
   @BetaApi
-  default Lt lt(Object other) {
+  public final Lt lt(Object other) {
     return new Lt(this, Constant.of(other));
   }
 
@@ -706,7 +712,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the less than or equal to comparison.
    */
   @BetaApi
-  default Lte lte(Expr other) {
+  public final Lte lte(Expr other) {
     return new Lte(this, other);
   }
 
@@ -724,7 +730,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the less than or equal to comparison.
    */
   @BetaApi
-  default Lte lte(Object other) {
+  public final Lte lte(Object other) {
     return new Lte(this, Constant.of(other));
   }
 
@@ -744,7 +750,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'IN' comparison.
    */
   @BetaApi
-  default In inAny(Object... other) {
+  public final In inAny(Object... other) {
     return new In(this, toExprList(other));
   }
 
@@ -763,7 +769,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'NOT IN' comparison.
    */
   @BetaApi
-  default Not notInAny(Object... other) {
+  public final Not notInAny(Object... other) {
     return new Not(inAny(other));
   }
 
@@ -783,7 +789,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the concatenated array.
    */
   @BetaApi
-  default ArrayConcat arrayConcat(List<Object> array) {
+  public final ArrayConcat arrayConcat(List<Object> array) {
     return new ArrayConcat(this, toExprList(array.toArray()));
   }
 
@@ -801,7 +807,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'array_contains' comparison.
    */
   @BetaApi
-  default ArrayContains arrayContains(Expr element) {
+  public final ArrayContains arrayContains(Expr element) {
     return new ArrayContains(this, element);
   }
 
@@ -819,7 +825,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'array_contains' comparison.
    */
   @BetaApi
-  default ArrayContains arrayContains(Object element) {
+  public final ArrayContains arrayContains(Object element) {
     return new ArrayContains(this, Constant.of(element));
   }
 
@@ -837,7 +843,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'array_contains_all' comparison.
    */
   @BetaApi
-  default ArrayContainsAll arrayContainsAll(Expr... elements) {
+  public final ArrayContainsAll arrayContainsAll(Expr... elements) {
     return new ArrayContainsAll(this, Arrays.asList(elements));
   }
 
@@ -855,7 +861,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'array_contains_all' comparison.
    */
   @BetaApi
-  default ArrayContainsAll arrayContainsAll(Object... elements) {
+  public final ArrayContainsAll arrayContainsAll(Object... elements) {
     return new ArrayContainsAll(this, toExprList(elements));
   }
 
@@ -873,7 +879,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'array_contains_any' comparison.
    */
   @BetaApi
-  default ArrayContainsAny arrayContainsAny(Expr... elements) {
+  public final ArrayContainsAny arrayContainsAny(Expr... elements) {
     return new ArrayContainsAny(this, Arrays.asList(elements));
   }
 
@@ -892,7 +898,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'array_contains_any' comparison.
    */
   @BetaApi
-  default ArrayContainsAny arrayContainsAny(Object... elements) {
+  public final ArrayContainsAny arrayContainsAny(Object... elements) {
     return new ArrayContainsAny(this, toExprList(elements));
   }
 
@@ -909,7 +915,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the length of the array.
    */
   @BetaApi
-  default ArrayLength arrayLength() {
+  public final ArrayLength arrayLength() {
     return new ArrayLength(this);
   }
 
@@ -926,7 +932,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the length of the array.
    */
   @BetaApi
-  default ArrayReverse arrayReverse() {
+  public final ArrayReverse arrayReverse() {
     return new ArrayReverse(this);
   }
 
@@ -945,7 +951,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'isNaN' check.
    */
   @BetaApi
-  default IsNaN isNaN() {
+  public final IsNaN isNaN() {
     return new IsNaN(this);
   }
 
@@ -962,7 +968,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'exists' check.
    */
   @BetaApi
-  default Exists exists() {
+  public final Exists exists() {
     return new Exists(this);
   }
 
@@ -981,7 +987,7 @@ public interface Expr {
    * @return A new {@code Accumulator} representing the 'sum' aggregation.
    */
   @BetaApi
-  default Sum sum() {
+  public final Sum sum() {
     return new Sum(this, false);
   }
 
@@ -999,7 +1005,7 @@ public interface Expr {
    * @return A new {@code Accumulator} representing the 'avg' aggregation.
    */
   @BetaApi
-  default Avg avg() {
+  public final Avg avg() {
     return new Avg(this, false);
   }
 
@@ -1017,7 +1023,7 @@ public interface Expr {
    * @return A new {@code Accumulator} representing the 'count' aggregation.
    */
   @BetaApi
-  default Count count() {
+  public final Count count() {
     return new Count(this);
   }
 
@@ -1034,7 +1040,7 @@ public interface Expr {
    * @return A new {@code Accumulator} representing the 'min' aggregation.
    */
   @BetaApi
-  default Min min() {
+  public final Min min() {
     return new Min(this, false);
   }
 
@@ -1051,7 +1057,7 @@ public interface Expr {
    * @return A new {@code Accumulator} representing the 'max' aggregation.
    */
   @BetaApi
-  default Max max() {
+  public final Max max() {
     return new Max(this, false);
   }
 
@@ -1070,7 +1076,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the length of the string.
    */
   @BetaApi
-  default CharLength charLength() {
+  public final CharLength charLength() {
     return new CharLength(this);
   }
 
@@ -1087,7 +1093,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the byte length of the string.
    */
   @BetaApi
-  default ByteLength byteLength() {
+  public final ByteLength byteLength() {
     return new ByteLength(this);
   }
 
@@ -1105,7 +1111,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'like' comparison.
    */
   @BetaApi
-  default Like like(String pattern) {
+  public final Like like(String pattern) {
     return new Like(this, Constant.of(pattern));
   }
 
@@ -1123,7 +1129,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'like' comparison.
    */
   @BetaApi
-  default Like like(Expr pattern) {
+  public final Like like(Expr pattern) {
     return new Like(this, pattern);
   }
 
@@ -1142,7 +1148,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'contains' comparison.
    */
   @BetaApi
-  default RegexContains regexContains(String regex) {
+  public final RegexContains regexContains(String regex) {
     return new RegexContains(this, Constant.of(regex));
   }
 
@@ -1161,7 +1167,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'contains' comparison.
    */
   @BetaApi
-  default RegexContains regexContains(Expr regex) {
+  public final RegexContains regexContains(Expr regex) {
     return new RegexContains(this, regex);
   }
 
@@ -1179,7 +1185,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the regular expression match.
    */
   @BetaApi
-  default RegexMatch regexMatches(String regex) {
+  public final RegexMatch regexMatches(String regex) {
     return new RegexMatch(this, Constant.of(regex));
   }
 
@@ -1197,7 +1203,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the regular expression match.
    */
   @BetaApi
-  default RegexMatch regexMatches(Expr regex) {
+  public final RegexMatch regexMatches(Expr regex) {
     return new RegexMatch(this, regex);
   }
 
@@ -1215,7 +1221,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'contains' comparison.
    */
   @BetaApi
-  default StrContains strContains(String substring) {
+  public final StrContains strContains(String substring) {
     return new StrContains(this, Constant.of(substring));
   }
 
@@ -1234,7 +1240,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'contains' comparison.
    */
   @BetaApi
-  default StrContains strContains(Expr expr) {
+  public final StrContains strContains(Expr expr) {
     return new StrContains(this, expr);
   }
 
@@ -1252,7 +1258,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'starts with' comparison.
    */
   @BetaApi
-  default StartsWith startsWith(String prefix) {
+  public final StartsWith startsWith(String prefix) {
     return new StartsWith(this, Constant.of(prefix));
   }
 
@@ -1271,7 +1277,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'starts with' comparison.
    */
   @BetaApi
-  default StartsWith startsWith(Expr prefix) {
+  public final StartsWith startsWith(Expr prefix) {
     return new StartsWith(this, prefix);
   }
 
@@ -1289,7 +1295,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'ends with' comparison.
    */
   @BetaApi
-  default EndsWith endsWith(String postfix) {
+  public final EndsWith endsWith(String postfix) {
     return new EndsWith(this, Constant.of(postfix));
   }
 
@@ -1308,7 +1314,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the 'ends with' comparison.
    */
   @BetaApi
-  default EndsWith endsWith(Expr postfix) {
+  public final EndsWith endsWith(Expr postfix) {
     return new EndsWith(this, postfix);
   }
 
@@ -1326,7 +1332,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the concatenated string.
    */
   @BetaApi
-  default StrConcat strConcat(Expr... elements) {
+  public final StrConcat strConcat(Expr... elements) {
     return new StrConcat(this, Arrays.asList(elements));
   }
 
@@ -1344,7 +1350,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the concatenated string.
    */
   @BetaApi
-  default StrConcat strConcat(Object... elements) {
+  public final StrConcat strConcat(Object... elements) {
     return new StrConcat(this, toExprList(elements));
   }
 
@@ -1361,7 +1367,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the lowercase string.
    */
   @BetaApi
-  default ToLower toLower() {
+  public final ToLower toLower() {
     return new ToLower(this);
   }
 
@@ -1378,7 +1384,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the uppercase string.
    */
   @BetaApi
-  default ToUpper toUpper() {
+  public final ToUpper toUpper() {
     return new ToUpper(this);
   }
 
@@ -1395,7 +1401,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the trimmed string.
    */
   @BetaApi
-  default Trim trim() {
+  public final Trim trim() {
     return new Trim(this);
   }
 
@@ -1412,7 +1418,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the reversed string.
    */
   @BetaApi
-  default Reverse reverse() {
+  public final Reverse reverse() {
     return new Reverse(this);
   }
 
@@ -1432,7 +1438,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the string with the first occurrence replaced.
    */
   @BetaApi
-  default ReplaceFirst replaceFirst(String find, String replace) {
+  public final ReplaceFirst replaceFirst(String find, String replace) {
     return new ReplaceFirst(this, Constant.of(find), Constant.of(replace));
   }
 
@@ -1454,7 +1460,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the string with the first occurrence replaced.
    */
   @BetaApi
-  default ReplaceFirst replaceFirst(Expr find, Expr replace) {
+  public final ReplaceFirst replaceFirst(Expr find, Expr replace) {
     return new ReplaceFirst(this, find, replace);
   }
 
@@ -1474,7 +1480,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the string with all occurrences replaced.
    */
   @BetaApi
-  default ReplaceAll replaceAll(String find, String replace) {
+  public final ReplaceAll replaceAll(String find, String replace) {
     return new ReplaceAll(this, Constant.of(find), Constant.of(replace));
   }
 
@@ -1496,7 +1502,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the string with all occurrences replaced.
    */
   @BetaApi
-  default ReplaceAll replaceAll(Expr find, Expr replace) {
+  public final ReplaceAll replaceAll(Expr find, Expr replace) {
     return new ReplaceAll(this, find, replace);
   }
 
@@ -1517,7 +1523,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the value associated with the given key in the map.
    */
   @BetaApi
-  default MapGet mapGet(String key) {
+  public final MapGet mapGet(String key) {
     return new MapGet(this, key);
   }
 
@@ -1535,7 +1541,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the cosine distance between the two vectors.
    */
   @BetaApi
-  default CosineDistance cosineDistance(Expr other) {
+  public final CosineDistance cosineDistance(Expr other) {
     return new CosineDistance(this, other);
   }
 
@@ -1553,7 +1559,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the Cosine distance between the two vectors.
    */
   @BetaApi
-  default CosineDistance cosineDistance(double[] other) {
+  public final CosineDistance cosineDistance(double[] other) {
     return new CosineDistance(this, Constant.vector(other));
   }
 
@@ -1571,7 +1577,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the Euclidean distance between the two vectors.
    */
   @BetaApi
-  default EuclideanDistance euclideanDistance(double[] other) {
+  public final EuclideanDistance euclideanDistance(double[] other) {
     return new EuclideanDistance(this, Constant.vector(other));
   }
 
@@ -1589,7 +1595,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the Euclidean distance between the two vectors.
    */
   @BetaApi
-  default EuclideanDistance euclideanDistance(Expr other) {
+  public final EuclideanDistance euclideanDistance(Expr other) {
     return new EuclideanDistance(this, other);
   }
 
@@ -1607,7 +1613,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the dot product between the two vectors.
    */
   @BetaApi
-  default DotProduct dotProduct(double[] other) {
+  public final DotProduct dotProduct(double[] other) {
     return new DotProduct(this, Constant.vector(other));
   }
 
@@ -1625,7 +1631,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the dot product between the two vectors.
    */
   @BetaApi
-  default DotProduct dotProduct(Expr other) {
+  public final DotProduct dotProduct(Expr other) {
     return new DotProduct(this, other);
   }
 
@@ -1642,7 +1648,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the length of the array.
    */
   @BetaApi
-  default VectorLength vectorLength() {
+  public final VectorLength vectorLength() {
     return new VectorLength(this);
   }
 
@@ -1664,7 +1670,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the number of microseconds since the epoch.
    */
   @BetaApi
-  default TimestampToUnixMicros timestampToUnixMicros() {
+  public final TimestampToUnixMicros timestampToUnixMicros() {
     return new TimestampToUnixMicros(this);
   }
 
@@ -1682,7 +1688,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the timestamp.
    */
   @BetaApi
-  default UnixMicrosToTimestamp unixMicrosToTimestamp() {
+  public final UnixMicrosToTimestamp unixMicrosToTimestamp() {
     return new UnixMicrosToTimestamp(this);
   }
 
@@ -1702,7 +1708,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the number of milliseconds since the epoch.
    */
   @BetaApi
-  default TimestampToUnixMillis timestampToUnixMillis() {
+  public final TimestampToUnixMillis timestampToUnixMillis() {
     return new TimestampToUnixMillis(this);
   }
 
@@ -1720,7 +1726,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the timestamp.
    */
   @BetaApi
-  default UnixMillisToTimestamp unixMillisToTimestamp() {
+  public final UnixMillisToTimestamp unixMillisToTimestamp() {
     return new UnixMillisToTimestamp(this);
   }
 
@@ -1740,7 +1746,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the number of seconds since the epoch.
    */
   @BetaApi
-  default TimestampToUnixSeconds timestampToUnixSeconds() {
+  public final TimestampToUnixSeconds timestampToUnixSeconds() {
     return new TimestampToUnixSeconds(this);
   }
 
@@ -1758,7 +1764,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the timestamp.
    */
   @BetaApi
-  default UnixSecondsToTimestamp unixSecondsToTimestamp() {
+  public final UnixSecondsToTimestamp unixSecondsToTimestamp() {
     return new UnixSecondsToTimestamp(this);
   }
 
@@ -1778,7 +1784,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the resulting timestamp.
    */
   @BetaApi
-  default TimestampAdd timestampAdd(Expr unit, Expr amount) {
+  public final TimestampAdd timestampAdd(Expr unit, Expr amount) {
     return new TimestampAdd(this, unit, amount);
   }
 
@@ -1798,7 +1804,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the resulting timestamp.
    */
   @BetaApi
-  default TimestampAdd timestampAdd(String unit, Double amount) {
+  public final TimestampAdd timestampAdd(String unit, Double amount) {
     return new TimestampAdd(this, Constant.of(unit), Constant.of(amount));
   }
 
@@ -1818,7 +1824,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the resulting timestamp.
    */
   @BetaApi
-  default TimestampSub timestampSub(Expr unit, Expr amount) {
+  public final TimestampSub timestampSub(Expr unit, Expr amount) {
     return new TimestampSub(this, unit, amount);
   }
 
@@ -1838,7 +1844,7 @@ public interface Expr {
    * @return A new {@code Expr} representing the resulting timestamp.
    */
   @BetaApi
-  default TimestampSub timestampSub(String unit, Double amount) {
+  public final TimestampSub timestampSub(String unit, Double amount) {
     return new TimestampSub(this, Constant.of(unit), Constant.of(amount));
   }
 
@@ -1858,7 +1864,7 @@ public interface Expr {
    * @return A new {@code Ordering} for ascending sorting.
    */
   @BetaApi
-  default Ordering ascending() {
+  public final Ordering ascending() {
     return Ordering.ascending(this);
   }
 
@@ -1876,7 +1882,7 @@ public interface Expr {
    * @return A new {@code Ordering} for descending sorting.
    */
   @BetaApi
-  default Ordering descending() {
+  public final Ordering descending() {
     return Ordering.descending(this);
   }
 
@@ -1901,7 +1907,10 @@ public interface Expr {
    *     expression and associates it with the provided alias.
    */
   @BetaApi
-  default Selectable as(String alias) {
+  public Selectable as(String alias) {
     return new ExprWithAlias<>(this, alias);
   }
+
+  @InternalApi
+  abstract Value toProto();
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Expr.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Expr.java
@@ -48,6 +48,10 @@ public abstract class Expr {
   Expr() {
   }
 
+  private static Expr castToExprOrConvertToConstant(Object o) {
+    return o instanceof Expr ? (Expr) o : Constant.of(o);
+  }
+
   // Arithmetic Operators
 
   /**
@@ -83,7 +87,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Add add(Object other) {
-    return new Add(this, Constant.of(other));
+    return new Add(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -119,7 +123,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Subtract subtract(Object other) {
-    return new Subtract(this, Constant.of(other));
+    return new Subtract(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -155,7 +159,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Multiply multiply(Object other) {
-    return new Multiply(this, Constant.of(other));
+    return new Multiply(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -191,7 +195,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Divide divide(Object other) {
-    return new Divide(this, Constant.of(other));
+    return new Divide(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -227,7 +231,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Mod mod(Object other) {
-    return new Mod(this, Constant.of(other));
+    return new Mod(this, castToExprOrConvertToConstant(other));
   }
 
   // /**
@@ -263,7 +267,7 @@ public abstract class Expr {
   //  */
   // @BetaApi
   // default BitAnd bitAnd(Object other) {
-  //   return new BitAnd(this, Constant.of(other));
+  //   return new BitAnd(this, of(other));
   // }
   //
   // /**
@@ -299,7 +303,7 @@ public abstract class Expr {
   //  */
   // @BetaApi
   // default BitOr bitOr(Object other) {
-  //   return new BitOr(this, Constant.of(other));
+  //   return new BitOr(this, of(other));
   // }
   //
   // /**
@@ -335,7 +339,7 @@ public abstract class Expr {
   //  */
   // @BetaApi
   // default BitXor bitXor(Object other) {
-  //   return new BitXor(this, Constant.of(other));
+  //   return new BitXor(this, of(other));
   // }
   //
   // /**
@@ -388,7 +392,7 @@ public abstract class Expr {
   //  */
   // @BetaApi
   // default BitLeftShift bitLeftShift(Object other) {
-  //   return new BitLeftShift(this, Constant.of(other));
+  //   return new BitLeftShift(this, of(other));
   // }
   //
   // /**
@@ -424,7 +428,7 @@ public abstract class Expr {
   //  */
   // @BetaApi
   // default BitRightShift bitRightShift(Object other) {
-  //   return new BitRightShift(this, Constant.of(other));
+  //   return new BitRightShift(this, of(other));
   // }
 
   // Logical Functions
@@ -468,7 +472,7 @@ public abstract class Expr {
    * @return A new {@code Expr} representing the logical max operation.
    */
   public final LogicalMax logicalMax(Object other) {
-    return new LogicalMax(this, Constant.of(other));
+    return new LogicalMax(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -510,7 +514,7 @@ public abstract class Expr {
    * @return A new {@code Expr} representing the logical min operation.
    */
   public final LogicalMin logicalMin(Object other) {
-    return new LogicalMin(this, Constant.of(other));
+    return new LogicalMin(this, castToExprOrConvertToConstant(other));
   }
 
   // Comparison Operators
@@ -548,7 +552,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Eq eq(Object other) {
-    return new Eq(this, Constant.of(other));
+    return new Eq(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -584,7 +588,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Neq neq(Object other) {
-    return new Neq(this, Constant.of(other));
+    return new Neq(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -620,7 +624,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Gt gt(Object other) {
-    return new Gt(this, Constant.of(other));
+    return new Gt(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -658,7 +662,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Gte gte(Object other) {
-    return new Gte(this, Constant.of(other));
+    return new Gte(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -694,7 +698,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Lt lt(Object other) {
-    return new Lt(this, Constant.of(other));
+    return new Lt(this, castToExprOrConvertToConstant(other));
   }
 
   /**
@@ -731,7 +735,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final Lte lte(Object other) {
-    return new Lte(this, Constant.of(other));
+    return new Lte(this, castToExprOrConvertToConstant(other));
   }
 
   // IN operator
@@ -826,7 +830,7 @@ public abstract class Expr {
    */
   @BetaApi
   public final ArrayContains arrayContains(Object element) {
-    return new ArrayContains(this, Constant.of(element));
+    return new ArrayContains(this, castToExprOrConvertToConstant(element));
   }
 
   /**

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ExprWithAlias.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ExprWithAlias.java
@@ -17,9 +17,10 @@
 package com.google.cloud.firestore.pipeline.expressions;
 
 import com.google.api.core.InternalApi;
+import com.google.firestore.v1.Value;
 
 @InternalApi
-public final class ExprWithAlias<T extends Expr> implements Expr, Selectable {
+public final class ExprWithAlias<T extends Expr> extends Expr implements Selectable {
 
   private final String alias;
   private final T expr;
@@ -43,5 +44,10 @@ public final class ExprWithAlias<T extends Expr> implements Expr, Selectable {
   @Override
   public Selectable as(String alias) {
     return new ExprWithAlias<>(this.expr, alias);
+  }
+
+  @Override
+  Value toProto() {
+    return expr.toProto();
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Field.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Field.java
@@ -22,6 +22,7 @@ import com.google.cloud.firestore.FieldPath;
 import com.google.cloud.firestore.Pipeline;
 import com.google.common.base.Objects;
 import com.google.firestore.v1.Value;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -41,7 +42,7 @@ import javax.annotation.Nullable;
  * }</pre>
  */
 @BetaApi
-public final class Field implements Expr, Selectable {
+public final class Field extends Expr implements Selectable {
   public static final String DOCUMENT_ID = "__name__";
   private final FieldPath path;
   @Nullable private Pipeline pipeline; // Nullable
@@ -49,7 +50,6 @@ public final class Field implements Expr, Selectable {
   private Field(FieldPath path) {
     this.path = path;
   }
-
   /**
    * Creates a {@code Field} instance representing the field at the given path.
    *

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/FilterCondition.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/FilterCondition.java
@@ -17,6 +17,12 @@
 package com.google.cloud.firestore.pipeline.expressions;
 
 import com.google.api.core.BetaApi;
+import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public interface FilterCondition extends Expr {}
+public abstract class FilterCondition extends Function {
+
+  FilterCondition(String name, ImmutableList<? extends Expr> params) {
+    super(name, params);
+  }
+}

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Function.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Function.java
@@ -44,16 +44,17 @@ import java.util.stream.Collectors;
  * <p>You can chain together these static functions to create more complex expressions.
  */
 @BetaApi
-public class Function implements Expr {
+public class Function extends Expr {
   private final String name;
   private final List<Expr> params;
 
-  protected Function(String name, ImmutableList<? extends Expr> params) {
+  Function(String name, ImmutableList<? extends Expr> params) {
     this.name = name;
     this.params = Collections.unmodifiableList(params);
   }
 
   @InternalApi
+  @Override
   Value toProto() {
     return Value.newBuilder()
         .setFunctionValue(

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/FunctionUtils.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/FunctionUtils.java
@@ -17,7 +17,6 @@
 package com.google.cloud.firestore.pipeline.expressions;
 
 import com.google.api.core.InternalApi;
-import com.google.firestore.v1.ArrayValue;
 import com.google.firestore.v1.Value;
 import java.util.Arrays;
 import java.util.List;
@@ -27,11 +26,7 @@ import java.util.stream.Collectors;
 public final class FunctionUtils {
   @InternalApi
   public static Value exprToValue(Expr expr) {
-    if (expr == null) {
-      return Constant.of((String) null).toProto();
-    } else {
-      return expr.toProto();
-    }
+    return (expr == null ? Constant.NULL : expr).toProto();
   }
 
   @InternalApi

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/FunctionUtils.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/FunctionUtils.java
@@ -29,26 +29,8 @@ public final class FunctionUtils {
   public static Value exprToValue(Expr expr) {
     if (expr == null) {
       return Constant.of((String) null).toProto();
-    } else if (expr instanceof ExprWithAlias<?>) {
-      return exprToValue(((ExprWithAlias<?>) expr).getExpr());
-    } else if (expr instanceof Constant) {
-      return ((Constant) expr).toProto();
-    } else if (expr instanceof Field) {
-      return ((Field) expr).toProto();
-    } else if (expr instanceof Function) {
-      return ((Function) expr).toProto();
-    } else if (expr instanceof ListOfExprs) {
-      ListOfExprs listOfExprs = (ListOfExprs) expr;
-      return Value.newBuilder()
-          .setArrayValue(
-              ArrayValue.newBuilder()
-                  .addAllValues(
-                      listOfExprs.getConditions().stream()
-                          .map(FunctionUtils::exprToValue)
-                          .collect(Collectors.toList())))
-          .build();
     } else {
-      throw new IllegalArgumentException("Unsupported expression type: " + expr.getClass());
+      return expr.toProto();
     }
   }
 

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Gt.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Gt.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Gt extends Function implements FilterCondition {
+public final class Gt extends FilterCondition {
   @InternalApi
   Gt(Expr left, Expr right) {
     super("gt", ImmutableList.of(left, right == null ? Constant.nullValue() : right));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Gte.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Gte.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Gte extends Function implements FilterCondition {
+public final class Gte extends FilterCondition {
   @InternalApi
   Gte(Expr left, Expr right) {
     super("gte", ImmutableList.of(left, right == null ? Constant.nullValue() : right));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/If.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/If.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class If extends Function implements FilterCondition {
+public final class If extends FilterCondition {
   @InternalApi
   If(FilterCondition condition, Expr trueExpr, Expr falseExpr) {
     super(

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/In.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/In.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 @BetaApi
-public final class In extends Function implements FilterCondition {
+public final class In extends FilterCondition {
   @InternalApi
   In(Expr left, List<Expr> others) {
     super("in", ImmutableList.of(left, new ListOfExprs(others)));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/IsNaN.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/IsNaN.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class IsNaN extends Function implements FilterCondition {
+public final class IsNaN extends FilterCondition {
   @InternalApi
   IsNaN(Expr value) {
     super("is_nan", ImmutableList.of(value));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Like.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Like.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Like extends Function implements FilterCondition {
+public final class Like extends FilterCondition {
   @InternalApi
   Like(Expr expr, Expr pattern) {
     super("like", ImmutableList.of(expr, pattern));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ListOfExprs.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/ListOfExprs.java
@@ -18,10 +18,13 @@ package com.google.cloud.firestore.pipeline.expressions;
 
 import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
+import com.google.firestore.v1.ArrayValue;
+import com.google.firestore.v1.Value;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @InternalApi
-public final class ListOfExprs implements Expr {
+public final class ListOfExprs extends Expr {
   private final ImmutableList<Expr> conditions;
 
   @InternalApi
@@ -32,5 +35,15 @@ public final class ListOfExprs implements Expr {
   @InternalApi
   public List<Expr> getConditions() {
     return conditions;
+  }
+
+  @Override
+  Value toProto() {
+    Value.Builder builder = Value.newBuilder();
+    ArrayValue.Builder arrayBuilder = builder.getArrayValueBuilder();
+    for (Expr condition : conditions) {
+      arrayBuilder.addValues(condition.toProto());
+    }
+    return builder.build();
   }
 }

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Lt.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Lt.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Lt extends Function implements FilterCondition {
+public final class Lt extends FilterCondition {
   @InternalApi
   Lt(Expr left, Expr right) {
     super("lt", ImmutableList.of(left, right == null ? Constant.nullValue() : right));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Lte.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Lte.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Lte extends Function implements FilterCondition {
+public final class Lte extends FilterCondition {
   @InternalApi
   Lte(Expr left, Expr right) {
     super("lte", ImmutableList.of(left, right == null ? Constant.nullValue() : right));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Max.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Max.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Max extends Function implements Accumulator {
+public final class Max extends Accumulator {
   @InternalApi
   Max(Expr value, boolean distinct) {
     super("max", ImmutableList.of(value));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Min.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Min.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Min extends Function implements Accumulator {
+public final class Min extends Accumulator {
   @InternalApi
   Min(Expr value, boolean distinct) {
     super("min", ImmutableList.of(value));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Neq.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Neq.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Neq extends Function implements FilterCondition {
+public final class Neq extends FilterCondition {
   @InternalApi
   Neq(Expr left, Expr right) {
     super("neq", ImmutableList.of(left, right == null ? Constant.nullValue() : right));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Not.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Not.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Not extends Function implements FilterCondition {
+public final class Not extends FilterCondition {
   @InternalApi
   Not(Expr condition) {
     super("not", ImmutableList.of(condition));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Or.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Or.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 @BetaApi
-public final class Or extends Function implements FilterCondition {
+public final class Or extends FilterCondition {
   @InternalApi
   Or(List<FilterCondition> conditions) {
     super("or", ImmutableList.copyOf(conditions));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/RegexContains.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/RegexContains.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class RegexContains extends Function implements FilterCondition {
+public final class RegexContains extends FilterCondition {
   @InternalApi
   RegexContains(Expr expr, Expr regex) {
     super("regex_contains", ImmutableList.of(expr, regex));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/RegexMatch.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/RegexMatch.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class RegexMatch extends Function implements FilterCondition {
+public final class RegexMatch extends FilterCondition {
   @InternalApi
   RegexMatch(Expr expr, Expr regex) {
     super("regex_match", ImmutableList.of(expr, regex));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/StartsWith.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/StartsWith.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class StartsWith extends Function implements FilterCondition {
+public final class StartsWith extends FilterCondition {
   @InternalApi
   StartsWith(Expr expr, Expr prefix) {
     super("starts_with", ImmutableList.of(expr, prefix));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/StrContains.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/StrContains.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class StrContains extends Function implements FilterCondition {
+public final class StrContains extends FilterCondition {
   @InternalApi
   StrContains(Expr expr, Expr substring) {
     super("str_contains", ImmutableList.of(expr, substring));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Sum.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Sum.java
@@ -21,7 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
 
 @BetaApi
-public final class Sum extends Function implements Accumulator {
+public final class Sum extends Accumulator {
   @InternalApi
   Sum(Expr value, boolean distinct) {
     super("sum", ImmutableList.of(value));

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Xor.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/expressions/Xor.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 @BetaApi
-public final class Xor extends Function implements FilterCondition {
+public final class Xor extends FilterCondition {
   @InternalApi
   Xor(List<FilterCondition> conditions) {
     super("xor", ImmutableList.copyOf(conditions));


### PR DESCRIPTION
- Make NULL_VALUE constant as an optimization against create the same object over and over again.
- Make Expr polymorphic with `toProto()` method. This eliminates large condition structure. To `toProto()` is package-private for internal use. Package-private is only possible on classes (not interfaces), so I converted the Expr to an abstract class with package-private constructor to avoid customer extending it.
- Remove type parameters and use `?` instead. 
- Fix operators that take `Object` as parameter. `Object` might be of type `Expr` which cannot be passed through `Constant.of(..)` method. Instead we need to short circuit conversion, and simply return `Object` since it is already an `Expr`.