### PR TITLE
fix: getAuthenticationType in EmulatorCredentials should not throw.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-firestore</artifactId>
-  <version>3.30.5</version>
+  <version>3.30.6</version>
 </dependency>
 
 ```

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreOptions.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreOptions.java
@@ -313,7 +313,7 @@ public final class FirestoreOptions extends ServiceOptions<Firestore, FirestoreO
 
     @Override
     public String getAuthenticationType() {
-      throw new IllegalArgumentException("Not supported");
+      return "Unauthenticated";
     }
 
     @Override

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/EmulatorCredentials.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/EmulatorCredentials.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import java.io.IOException;
+import org.junit.Test;
+
+public class EmulatorCredentials {
+  @Test
+  public void implementsCredentials() throws IOException {
+    CredentialsProvider emulatorCredentials =
+        FixedCredentialsProvider.create(new FirestoreOptions.EmulatorCredentials());
+    assertEquals("Unauthenticated", emulatorCredentials.getCredentials().getAuthenticationType());
+    assertEquals(true, emulatorCredentials.getCredentials().hasRequestMetadata());
+    assertEquals(true, emulatorCredentials.getCredentials().hasRequestMetadataOnly());
+  }
+}


### PR DESCRIPTION
`EmulatorCredentials` extends the abstract `Credentials` class. The signature of `getAuthenticationType()` function of this class does not indicate that this API could throw, and based on [this description](https://cloud.google.com/java/docs/reference/google-auth-library/latest/com.google.auth.oauth2.OAuth2Credentials#com_google_auth_oauth2_OAuth2Credentials_getAuthenticationType__), I don't think it should.

Fixes #2002.