### PR TITLE
Add getDataSize() to DocumentSnapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-firestore</artifactId>
-  <version>3.31.6</version>
+  <version>3.31.7</version>
 </dependency>
 
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-firestore</artifactId>
-  <version>3.31.7</version>
+  <version>3.31.6</version>
 </dependency>
 
 ```

--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentSnapshot.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/DocumentSnapshot.java
@@ -468,4 +468,21 @@ public class DocumentSnapshot {
         "%s{doc=%s, fields=%s, readTime=%s, updateTime=%s, createTime=%s}",
         getClass().getSimpleName(), docRef, fields, readTime, updateTime, createTime);
   }
+
+  /**
+   * Returns the size of the data in this snapshot in bytes.
+   *
+   * @return The size of the data in bytes.
+   */
+  public int getDataSize() {
+    if (fields == null) {
+      return 0;
+    }
+
+    int totalSize = 0;
+    for (Value value : fields.values()) {
+      totalSize += value.getSerializedSize();
+    }
+    return totalSize;
+  }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -1521,4 +1521,23 @@ public class QueryTest {
 
     assertEquals(orderFields, query_.createImplicitOrderBy());
   }
+
+  @Test
+  public void documentSnapshotGetDataSize() {
+    // Test with an existing document
+    DocumentSnapshot snapshot = SINGLE_FIELD_SNAPSHOT;
+    int expectedSize = 0;
+    for (Value value : snapshot.getProtoFields().values()) {
+      expectedSize += value.getSerializedSize();
+    }
+    assertEquals(expectedSize, snapshot.getDataSize());
+
+    // Test with a non-existent document
+    DocumentSnapshot missingSnapshot =
+        DocumentSnapshot.fromMissing(
+            firestoreMock,
+            firestoreMock.document("coll/doc"),
+            Timestamp.now());
+    assertEquals(0, missingSnapshot.getDataSize());
+  }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -1535,9 +1535,7 @@ public class QueryTest {
     // Test with a non-existent document
     DocumentSnapshot missingSnapshot =
         DocumentSnapshot.fromMissing(
-            firestoreMock,
-            firestoreMock.document("coll/doc"),
-            Timestamp.now());
+            firestoreMock, firestoreMock.document("coll/doc"), Timestamp.now());
     assertEquals(0, missingSnapshot.getDataSize());
   }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -1536,9 +1536,7 @@ public class QueryTest {
   public void documentSnapshotGetDataSize_nonExistentDocument() {
     DocumentSnapshot missingSnapshot =
         DocumentSnapshot.fromMissing(
-            firestoreMock,
-            firestoreMock.document("coll/doc"),
-            Timestamp.now());
+            firestoreMock, firestoreMock.document("coll/doc"), Timestamp.now());
     assertEquals(0, missingSnapshot.getDataSize());
   }
 }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/QueryTest.java
@@ -1523,19 +1523,22 @@ public class QueryTest {
   }
 
   @Test
-  public void documentSnapshotGetDataSize() {
-    // Test with an existing document
+  public void documentSnapshotGetDataSize_existingDocument() {
     DocumentSnapshot snapshot = SINGLE_FIELD_SNAPSHOT;
     int expectedSize = 0;
     for (Value value : snapshot.getProtoFields().values()) {
       expectedSize += value.getSerializedSize();
     }
     assertEquals(expectedSize, snapshot.getDataSize());
+  }
 
-    // Test with a non-existent document
+  @Test
+  public void documentSnapshotGetDataSize_nonExistentDocument() {
     DocumentSnapshot missingSnapshot =
         DocumentSnapshot.fromMissing(
-            firestoreMock, firestoreMock.document("coll/doc"), Timestamp.now());
+            firestoreMock,
+            firestoreMock.document("coll/doc"),
+            Timestamp.now());
     assertEquals(0, missingSnapshot.getDataSize());
   }
 }


### PR DESCRIPTION
This method calculates and returns the total size of the data stored in the DocumentSnapshot in bytes.

- Iterates through the protobuf `Value` messages in the `fields` map.
- Sums the `getSerializedSize()` of each `Value`.
- Returns 0 if the document does not exist (fields is null).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
