### PR TITLE
fix: Further improve performance of the UTF-8 string comparison logic

### DIFF
--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/OrderTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/OrderTest.java
@@ -218,7 +218,7 @@ public class OrderTest {
       ByteString b2 = ByteString.copyFromUtf8(s2);
       int expected = compareByteStrings(b1, b2);
 
-      if (actual == expected) {
+      if (Integer.signum(actual) == Integer.signum(expected)) {
         passCount++;
       } else {
         errors.add(
@@ -227,9 +227,12 @@ public class OrderTest {
                 + "\", s2=\""
                 + s2
                 + "\") returned "
+                + signName(actual)
+                + " ("
                 + actual
+                + ")"
                 + ", but expected "
-                + expected
+                + signName(expected)
                 + " (i="
                 + i
                 + ", s1.length="
@@ -249,6 +252,16 @@ public class OrderTest {
         sb.append("\nerrors[").append(i).append("]: ").append(errors.get(i));
       }
       fail(sb.toString());
+    }
+  }
+
+  private static String signName(int value) {
+    if (value < 0) {
+      return "a negative value";
+    } else if (value > 0) {
+      return "a positive value";
+    } else {
+      return "0";
     }
   }
 


### PR DESCRIPTION
This PR both improves performance and simplifies the UTF-8 string comparison logic. It addresses prior performance regressions by introducing a more optimized algorithm for string ordering.

The semantics of the UTF-8 string comparison logic were originally fixed by #1967, but this fix caused a material performance degradation, which was then improved by #2021. The performance was, however, presumably still sub-optimal, and this PR further improves the speed back to close to its original speed and, serendipitously, simplifies the algorithm too.

This PR effectively ports the following two PRs from the firebase-android-sdk repository:

- https://github.com/firebase/firebase-android-sdk/pull/7098
- https://github.com/firebase/firebase-android-sdk/pull/7109

### Highlights

* **Performance Optimization**: The `compareUtf8Strings()` method in `Order.java` has been  rewritten to improve performance and simplify its logic. The new algorithm leverages the relationship between UTF-8 and UTF-16 representations for more efficient string comparison, avoiding costly byte string conversions.
* **Algorithm Simplification**: The previous logic involving `codePointAt` and `ByteString.copyFromUtf8` for non-ASCII characters has been replaced with a more straightforward character-by-character comparison that intelligently handles surrogate pairs.
* **Test Robustness**: The `OrderTest.java` has been updated to improve the robustness of the `compareUtf8Strings()` test. Instead of asserting exact return values, it now checks the `signum` (sign) of the comparison result, which is a more appropriate way to validate comparator behavior.
