### PR TITLE
docs: add an example to the detailed comment in compareUtf8Strings()

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Order.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Order.java
@@ -177,7 +177,7 @@ class Order implements Comparator<Value> {
     // direct comparison of the UTF-16 code units, as would be done in case 1, would erroneously
     // produce the _opposite_ ordering, because 0xFFFD is _greater than_ 0xD83D. As it turns out,
     // this relative ordering holds for all comparisons of UTF-16 code points requiring a surrogate
-    // pair with those that do not.    
+    // pair with those that do not.
     final int length = Math.min(left.length(), right.length());
     for (int i = 0; i < length; i++) {
       final char leftChar = left.charAt(i);


### PR DESCRIPTION
This PR enhances the documentation for the `compareUtf8Strings()` method by adding a concrete example. This example illustrates the nuances of comparing Unicode strings, particularly how characters represented by surrogate pairs in UTF-16 can compare differently than the lexicographical comparison of their UTF-8 encoding.

This PR is in response to review comment https://github.com/firebase/firebase-android-sdk/pull/7098#pullrequestreview-2994517806 and is a port of https://github.com/firebase/firebase-android-sdk/pull/7113