### PR TITLE
chore: manual update of update_generation_config.sh

### DIFF
--- a/.github/scripts/update_generation_config.sh
+++ b/.github/scripts/update_generation_config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 # This script should be run at the root of the repository.
 # This script is used to update googleapis_commitish, gapic_generator_version,
 # and libraries_bom_version in generation configuration at the time of running

--- a/.github/scripts/update_generation_config.sh
+++ b/.github/scripts/update_generation_config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 # This script should be run at the root of the repository.
 # This script is used to update googleapis_commitish, gapic_generator_version,
 # and libraries_bom_version in generation configuration at the time of running

--- a/.github/workflows/update_generation_config.yaml
+++ b/.github/workflows/update_generation_config.yaml
@@ -18,7 +18,6 @@ on:
   schedule:
   - cron: '0 2 * * *'
   workflow_dispatch:
-
 jobs:
   update-generation-config:
     runs-on: ubuntu-24.04
@@ -44,4 +43,3 @@ jobs:
           --repo ${{ github.repository }}
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
-

--- a/.github/workflows/update_generation_config.yaml
+++ b/.github/workflows/update_generation_config.yaml
@@ -18,6 +18,7 @@ on:
   schedule:
   - cron: '0 2 * * *'
   workflow_dispatch:
+
 jobs:
   update-generation-config:
     runs-on: ubuntu-24.04
@@ -43,3 +44,4 @@ jobs:
           --repo ${{ github.repository }}
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+


### PR DESCRIPTION
Unfortunately, https://github.com/googleapis/sdk-platform-java/pull/3853 cannot be automatically propagated. 

This PR manually updates this script with the latest.


Confirmation in https://github.com/googleapis/java-firestore/actions/runs/16504611609