### PR TITLE
chore: update CODEOWNERS to simplify ownership rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,20 +7,8 @@
 # The @googleapis/api-firestore @googleapis/firestore-dpe is the default owner for changes in this repo
 *                       @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
 
-# for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/api-firestore @googleapis/firestore-dpe
-
-# For generated Java code
-proto-*/                    @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
-grpc-*/                     @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
-# Generated code pattern in google-cloud-firestore and google-cloud-firestore-admin
-**/*Client.java             @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
-**/*Settings.java           @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
-**/*ClientHttpJsonTest.java @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
-**/*ClientTest.java         @googleapis/yoshi-java @googleapis/api-firestore @googleapis/firestore-dpe
-
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers
+samples/**/*.java       @googleapis/yoshi-java @googleapis/api-firestore @googleapis/java-samples-reviewers
 
 # Generated snippets should not be owned by samples reviewers
 samples/snippets/generated/       @googleapis/yoshi-java


### PR DESCRIPTION
Removed specific ownership rules for handwritten and generated Java code.