### PR TITLE
fix: Remove client-side assertion for Union with subcollection and delegate to backend

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Pipeline.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Pipeline.java
@@ -1049,11 +1049,6 @@ public final class Pipeline {
    * @return A new {@code Pipeline} object with this stage appended to the stage list.
    */
   public Pipeline union(Pipeline other) {
-    if (other.rpcContext == null) {
-      throw new IllegalArgumentException(
-          "Union only supports combining root pipelines, doesn't support relative scope Pipeline"
-              + " like relative subcollection pipeline");
-    }
     return append(new Union(other));
   }
 

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineSubqueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineSubqueryTest.java
@@ -68,9 +68,8 @@ public class ITPipelineSubqueryTest extends ITBaseTest {
   @Before
   public void setup() throws Exception {
     assumeFalse(
-        "This test suite only runs against the Enterprise edition in the Nightly environment.",
-        !getFirestoreEdition().equals(FirestoreEdition.ENTERPRISE)
-            || !"NIGHTLY".equals(getTargetBackend()));
+            "This test suite only runs against the Enterprise edition.",
+            !getFirestoreEdition().equals(FirestoreEdition.ENTERPRISE));
     if (collection != null) {
       return;
     }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineSubqueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineSubqueryTest.java
@@ -68,8 +68,8 @@ public class ITPipelineSubqueryTest extends ITBaseTest {
   @Before
   public void setup() throws Exception {
     assumeFalse(
-            "This test suite only runs against the Enterprise edition.",
-            !getFirestoreEdition().equals(FirestoreEdition.ENTERPRISE));
+        "This test suite only runs against the Enterprise edition.",
+        !getFirestoreEdition().equals(FirestoreEdition.ENTERPRISE));
     if (collection != null) {
       return;
     }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineSubqueryTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineSubqueryTest.java
@@ -984,20 +984,20 @@ public class ITPipelineSubqueryTest extends ITBaseTest {
 
   @Test
   public void testUnionWithSubqueryThrows() throws Exception {
-    IllegalArgumentException e =
+    ExecutionException e =
         assertThrows(
-            IllegalArgumentException.class,
+            ExecutionException.class,
             () -> {
               firestore
                   .pipeline()
                   .collection(collection.getPath())
-                  .union(PipelineSource.subcollection("subcollection"));
+                  .union(PipelineSource.subcollection("subcollection"))
+                  .execute()
+                  .get();
             });
 
-    assertThat(e)
-        .hasMessageThat()
+    assertThat(e.getCause().getMessage())
         .contains(
-            "Union only supports combining root pipelines, doesn't support relative scope Pipeline"
-                + " like relative subcollection pipeline");
+            "The 'subcollection(...)' stage can only be used at the start of a nested pipeline.");
   }
 }


### PR DESCRIPTION
This PR removes a client-side restriction in the `Union` stage of the Pipeline API and updates the corresponding integration test to expect the error from the backend instead.
### Changes
* **`Pipeline.java`**: Removed the assertion in `union(Pipeline other)` that threw an `IllegalArgumentException` when passing a relative scope pipeline (e.g., created via `PipelineSource.subcollection(...)`). This allows the pipeline to be constructed and sent to the backend.
* **`ITPipelineSubqueryTest.java`**: Updated `testUnionWithSubqueryThrows` to actually execute the pipeline (`.execute().get()`) and assert that it throws an `ExecutionException` caused by a backend `INVALID_ARGUMENT` error. The test now verifies that the error message contains: `"The 'subcollection(...)' stage can only be used at the start of a nested pipeline."`.