### PR TITLE
fix: enforce read-before-write in transaction execute()

### DIFF
--- a/google-cloud-firestore/src/main/java/com/google/cloud/firestore/ServerSideTransaction.java
+++ b/google-cloud-firestore/src/main/java/com/google/cloud/firestore/ServerSideTransaction.java
@@ -271,6 +271,7 @@ final class ServerSideTransaction extends Transaction {
   @Nonnull
   @Override
   public ApiFuture<Pipeline.Snapshot> execute(@Nonnull Pipeline pipeline) {
+    Preconditions.checkState(isEmpty(), READ_BEFORE_WRITE_ERROR_MSG);
     return execute(pipeline, new PipelineExecuteOptions());
   }
 
@@ -278,6 +279,7 @@ final class ServerSideTransaction extends Transaction {
   @Override
   public ApiFuture<Pipeline.Snapshot> execute(
       @Nonnull Pipeline pipeline, @Nonnull PipelineExecuteOptions options) {
+    Preconditions.checkState(isEmpty(), READ_BEFORE_WRITE_ERROR_MSG);
     try (TraceUtil.Scope ignored = transactionTraceContext.makeCurrent()) {
       return pipeline.execute(new PipelineExecuteOptions(), transactionId, null);
     }

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/TransactionTest.java
@@ -961,6 +961,27 @@ public class TransactionTest {
   }
 
   @Test
+  public void executeShouldThrowWhenInvokedAfterAWrite() throws Exception {
+    doReturn(beginResponse())
+        .when(firestoreMock)
+        .sendRequest(ArgumentMatchers.any(), ArgumentMatchers.any());
+
+    ApiFuture<Void> transaction =
+        firestoreMock.runTransaction(
+            t -> {
+              t.set(documentReference, LocalFirestoreHelper.SINGLE_FIELD_MAP);
+              t.execute(firestoreMock.pipeline().collection("test"));
+              return null;
+            });
+
+    ExecutionException executionException =
+        assertThrows(ExecutionException.class, transaction::get);
+    assertThat(executionException.getCause()).isInstanceOf(IllegalStateException.class);
+    assertThat(executionException.getCause().getMessage())
+        .contains("Firestore transactions require all reads to be executed before all writes");
+  }
+
+  @Test
   public void givesProperErrorMessageForCommittedTransaction() throws Exception {
     doReturn(beginResponse())
         .doReturn(commitResponse(0, 0))


### PR DESCRIPTION
This PR ensures that `Pipeline.execute()` calls within a transaction follow the requirement that all reads must occur before any writes. 

Previously, this check was missing from the `execute()` methods in `ServerSideTransaction.java`, allowing pipelines to be executed after writes had already been buffered.

Added a regression test in `TransactionTest.java`.