### PR TITLE
chore(firestore): rename nameddb to enterprise

### DIFF
--- a/.agents/skills/verify-local-changes/SKILL.md
+++ b/.agents/skills/verify-local-changes/SKILL.md
@@ -47,7 +47,7 @@ When running integration tests, configure your execution using properties or env
     -   `standard` (Default)
     -   `enterprise`
     -   *Note*: **Pipelines can only be run against `enterprise` editions**, while standard Queries run on both.
--   **`FIRESTORE_NAMED_DATABASE`**: 
+-   **`FIRESTORE_DATABASE_ID`**:
     -   Enterprise editions usually require a named database (often `enterprise`). Adjust this flag if pointing to specific instances.
 -   **`FIRESTORE_TARGET_BACKEND`**:
     -   `PROD` (Default)
@@ -58,14 +58,12 @@ When running integration tests, configure your execution using properties or env
 1.  **Identify modified integration tests** (usually Starting in `IT`).
 2.  **Run specific integration tests only** (isolated checks run quicker):
     ```bash
-    mvn verify -Penable-integration-tests -DFIRESTORE_EDITION=enterprise -DFIRESTORE_NAMED_DATABASE=enterprise -Dtest=ITTest#testMethod -Dclirr.skip=true -Denforcer.skip=true -fae
+    mvn verify -Penable-integration-tests -DFIRESTORE_EDITION=enterprise -DFIRESTORE_DATABASE_ID=enterprise -Dtest=ITTest#testMethod -Dclirr.skip=true -Denforcer.skip=true -fae
     ```
 3.  **Run the entire integration test suite** for the modified class if isolation tests pass:
     ```bash
-    mvn verify -Penable-integration-tests -DFIRESTORE_EDITION=enterprise -DFIRESTORE_NAMED_DATABASE=enterprise -Dtest=ITTest -Dclirr.skip=true -Denforcer.skip=true -fae
+    mvn verify -Penable-integration-tests -DFIRESTORE_EDITION=enterprise -DFIRESTORE_DATABASE_ID=enterprise -Dtest=ITTest -Dclirr.skip=true -Denforcer.skip=true -fae
     ```
-
-
 
 ---
 
@@ -74,7 +72,7 @@ When running integration tests, configure your execution using properties or env
 Run the full integration regression suite once you are confident subsets pass:
 
 ```bash
-mvn verify -Penable-integration-tests -DFIRESTORE_EDITION=enterprise -DFIRESTORE_NAMED_DATABASE=enterprise -Dclirr.skip=true -Denforcer.skip=true -fae
+mvn verify -Penable-integration-tests -DFIRESTORE_EDITION=enterprise -DFIRESTORE_DATABASE_ID=enterprise -Dclirr.skip=true -Denforcer.skip=true -fae
 ```
 
 ---
@@ -89,7 +87,7 @@ mvn verify -Penable-integration-tests -DFIRESTORE_EDITION=enterprise -DFIRESTORE
 If you run into issues executing tests with the commands above, **consult the Kokoro configuration files** as the ultimate source of truth:
 
 -   **Presubmit configurations**: See `.kokoro/presubmit/integration.cfg` (or `integration-named-db.cfg`)
--   **Nightly configurations**: See `.kokoro/nightly/integration.cfg` 
+-   **Nightly configurations**: See `.kokoro/nightly/integration.cfg` (or `integration-named-db.cfg`)
 -   **Build shell scripts**: See `.kokoro/build.sh`
 
 These files define the exact environment variables (e.g., specific endpoints or endpoints overrides) the CI server uses!

--- a/.github/scripts/update_generation_config.sh
+++ b/.github/scripts/update_generation_config.sh
@@ -48,13 +48,14 @@ function update_config() {
 }
 
 # Update an action to a new version in GitHub action.
+# the second argument must have the git tag (including "v").
 function update_action() {
     local key_word=$1
     local new_value=$2
     local file=$3
     echo "Update ${key_word} to ${new_value} in ${file}"
     # use a different delimiter because the key_word contains "/".
-    sed -i -e "s|${key_word}@v.*$|${key_word}@v${new_value}|" "${file}"
+    sed -i -e "s|${key_word}@[^ ]*$|${key_word}@${new_value}|" "${file}"
 }
 
 # The parameters of this script is:
@@ -143,12 +144,16 @@ rm -rf tmp-googleapis
 update_config "googleapis_commitish" "${latest_commit}" "${generation_config}"
 
 # Update gapic-generator-java version to the latest
-latest_version=$(get_latest_released_version "com.google.api" "gapic-generator-java")
-update_config "gapic_generator_version" "${latest_version}" "${generation_config}"
+latest_gapic_generator_version=$(get_latest_released_version "com.google.api" "gapic-generator-java")
+update_config "gapic_generator_version" "${latest_gapic_generator_version}" "${generation_config}"
 
-# Update composite action version to latest gapic-generator-java version
-update_action "googleapis/sdk-platform-java/.github/scripts" \
-  "${latest_version}" \
+# Update the GitHub Actions reference to the latest.
+# After the google-cloud-java monorepo migration of sdk-platform-java,
+# we cannot rely on the gapic-generator-java version tag. Let's use
+# the shared dependencies BOM version
+latest_shared_dependencies_bom_version=$(get_latest_released_version "com.google.cloud" "google-cloud-shared-dependencies")
+update_action "googleapis/google-cloud-java/sdk-platform-java/.github/scripts" \
+  "google-cloud-shared-dependencies/v${latest_shared_dependencies_bom_version}" \
   "${workflow}"
 
 # Update libraries-bom version to the latest

--- a/.github/workflows/renovate_config_check.yaml
+++ b/.github/workflows/renovate_config_check.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'renovate.json'
+      - '.github/workflows/renovate_config_check.yaml'
 
 jobs:
   renovate_bot_config_validation:
@@ -18,8 +19,6 @@ jobs:
       with:
         node-version: '22'
 
-    - name: Install Renovate and Config Validator
+    - name: Run Renovate Config Validator
       run: |
-        npm install -g npm@latest
-        npm install --global renovate
-        renovate-config-validator
+        npx --package renovate@43.136.0 renovate-config-validator

--- a/.kokoro/nightly/integration-named-db.cfg
+++ b/.kokoro/nightly/integration-named-db.cfg
@@ -13,7 +13,7 @@ env_vars: {
 
 env_vars: {
   key: "INTEGRATION_TEST_ARGS"
-  value: "-DFIRESTORE_NAMED_DATABASE=test-db -DFIRESTORE_EDITION=standard"
+  value: "-DFIRESTORE_DATABASE_ID=test-db -DFIRESTORE_EDITION=standard"
 }
 
 # TODO: remove this after we've migrated all tests and scripts

--- a/.kokoro/presubmit/graalvm-c.cfg
+++ b/.kokoro/presubmit/graalvm-c.cfg
@@ -13,7 +13,7 @@ env_vars: {
 
 env_vars: {
   key: "INTEGRATION_TEST_ARGS"
-  value: "-DFIRESTORE_NAMED_DATABASE=enterprise -DFIRESTORE_EDITION=enterprise"
+  value: "-DFIRESTORE_DATABASE_ID=enterprise -DFIRESTORE_EDITION=enterprise"
 }
 
 # TODO: remove this after we've migrated all tests and scripts

--- a/.kokoro/presubmit/graalvm-native-c.cfg
+++ b/.kokoro/presubmit/graalvm-native-c.cfg
@@ -13,7 +13,7 @@ env_vars: {
 
 env_vars: {
   key: "INTEGRATION_TEST_ARGS"
-  value: "-DFIRESTORE_NAMED_DATABASE=enterprise -DFIRESTORE_EDITION=enterprise"
+  value: "-DFIRESTORE_DATABASE_ID=enterprise -DFIRESTORE_EDITION=enterprise"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/integration-named-db.cfg
+++ b/.kokoro/presubmit/integration-named-db.cfg
@@ -13,7 +13,7 @@ env_vars: {
 
 env_vars: {
   key: "INTEGRATION_TEST_ARGS"
-  value: "-DFIRESTORE_NAMED_DATABASE=enterprise -DFIRESTORE_EDITION=enterprise"
+  value: "-DFIRESTORE_DATABASE_ID=enterprise -DFIRESTORE_EDITION=enterprise"
 }
 
 env_vars: {

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITBaseTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITBaseTest.java
@@ -82,7 +82,7 @@ public abstract class ITBaseTest {
   public static FirestoreOptions.Builder getOptionsBuilder() {
     FirestoreOptions.Builder optionsBuilder = FirestoreOptions.newBuilder();
 
-    String dbPropertyName = "FIRESTORE_NAMED_DATABASE";
+    String dbPropertyName = "FIRESTORE_DATABASE_ID";
     String namedDb = System.getProperty(dbPropertyName);
     if (namedDb == null) {
       namedDb = System.getenv(dbPropertyName);

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITE2ETracingTest.java
@@ -327,7 +327,7 @@ public abstract class ITE2ETracingTest extends ITBaseTest {
                   .build());
     }
 
-    String namedDb = System.getProperty("FIRESTORE_NAMED_DATABASE");
+    String namedDb = System.getProperty("FIRESTORE_DATABASE_ID");
     if (namedDb != null) {
       logger.log(Level.INFO, "Integration test using named database " + namedDb);
       optionsBuilder = optionsBuilder.setDatabaseId(namedDb);

--- a/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITTracingTest.java
+++ b/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITTracingTest.java
@@ -135,7 +135,7 @@ public abstract class ITTracingTest {
           otelOptionsBuilder.setOpenTelemetry(openTelemetrySdk).build());
     }
 
-    String namedDb = System.getProperty("FIRESTORE_NAMED_DATABASE");
+    String namedDb = System.getProperty("FIRESTORE_DATABASE_ID");
     if (namedDb != null) {
       logger.log(
           Level.INFO,


### PR DESCRIPTION
This PR aligns the Firestore integration test terminology in the Java SDK with the conventions used in other SDKs.

- Refactored the system property `FIRESTORE_NAMED_DATABASE` to `FIRESTORE_DATABASE_ID` for a more generic and consistent usage across platforms.
- Updated integration tests and GraalVM configurations to consume the new property.
- Note: Kokoro configuration filenames (`integration-named-db.cfg`) remain unchanged as they are required by the CI system infrastructure.